### PR TITLE
Require `@Inject` on all constructors - a la Misk

### DIFF
--- a/aff4/aff4-compression-snappy/src/main/kotlin/com/github/nava2/aff4/streams/compression/SnappyModule.kt
+++ b/aff4/aff4-compression-snappy/src/main/kotlin/com/github/nava2/aff4/streams/compression/SnappyModule.kt
@@ -5,6 +5,8 @@ import com.github.nava2.guice.KAbstractModule
 
 object SnappyModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     bindSet<CompressionMethod> {
       to<SnappyCompression>()
     }

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModelModule.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModelModule.kt
@@ -6,6 +6,8 @@ import kotlin.reflect.KClass
 
 object Aff4RdfModelModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     bindSet<KClass<out Aff4RdfModel>> {
       for (subclass in Aff4RdfModel::class.sealedSubclasses) {
         toInstance(subclass)

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4BaseStreamModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4BaseStreamModule.kt
@@ -6,6 +6,8 @@ import com.github.nava2.guice.KAbstractModule
 
 object Aff4BaseStreamModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     install(Aff4ImageStreamModule)
     install(Aff4MapStreamModule)
   }

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4CoreModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4CoreModule.kt
@@ -26,6 +26,8 @@ annotation class ForImages
 
 object Aff4CoreModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     install(RdfRepositoryModule)
     install(RdfModelParserModule)
     install(Aff4RdfModelModule)

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4LogicalModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4LogicalModule.kt
@@ -5,6 +5,8 @@ import com.github.nava2.guice.KAbstractModule
 
 object Aff4LogicalModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     install(Aff4BaseStreamModule)
 
     install(Aff4ZipSegmentModule)

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/RandomsModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/RandomsModule.kt
@@ -6,7 +6,9 @@ import java.security.SecureRandom
 import java.util.Random
 
 object RandomsModule : KAbstractModule() {
-  override fun configure() = Unit
+  override fun configure() {
+    binder().requireAtInjectOnConstructors()
+  }
 
   @Provides
   fun providesRandom(): Random = SecureRandom.getInstanceStrong()

--- a/aff4/aff4-rdf/aff4-rdf-memory/src/main/kotlin/com/github/nava2/aff4/rdf/MemoryRdfRepositoryModule.kt
+++ b/aff4/aff4-rdf/aff4-rdf-memory/src/main/kotlin/com/github/nava2/aff4/rdf/MemoryRdfRepositoryModule.kt
@@ -5,6 +5,8 @@ import com.github.nava2.guice.to
 
 object MemoryRdfRepositoryModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     bind<RdfRepositoryConfiguration>().to<MemoryRdfRepositoryConfiguration>()
   }
 }

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/RdfRepositoryModule.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/RdfRepositoryModule.kt
@@ -10,6 +10,8 @@ import javax.inject.Singleton
 
 object RdfRepositoryModule : KAbstractModule() {
   override fun configure() {
+    binder().requireAtInjectOnConstructors()
+
     requireBinding(typeLiteral<RdfRepositoryConfiguration>().key)
 
     install(RdfConnectionScopeModule)


### PR DESCRIPTION
Requiring `@Inject` on the constructor of classes forces users to think about how this class is utilized. 

See: https://github.com/google/guice/blob/ad77056d77e72b15c8cdda310bf29311163e11d4/core/src/com/google/inject/Binder.java#L450