### PR TITLE
fixes Sha256FileSystemFactoryTests to work on UNIX and DOS systems

### DIFF
--- a/aff4/aff4-core/aff4-core-okio/src/main/kotlin/com/github/nava2/aff4/io/Sha256FileSystemFactory.kt
+++ b/aff4/aff4-core/aff4-core-okio/src/main/kotlin/com/github/nava2/aff4/io/Sha256FileSystemFactory.kt
@@ -27,11 +27,16 @@ class Sha256FileSystemFactory {
 
     private val mappings = HashBiMap.create<Path, Path>()
 
+    internal fun mapExternalPath(path: Path): Path {
+      val normalized = path.normalized()
+      val sha256 = Buffer().use { it.write(normalized.toString().encodeUtf8()).sha256() }.hex()
+      return (sha256.substring(0..1).toPath() / sha256).normalized()
+    }
+
     override fun onPathParameter(path: Path, functionName: String, parameterName: String): Path {
       val normalized = path.normalized()
       val mappedPath = mappings.computeIfAbsent(normalized) {
-        val sha256 = Buffer().use { it.write(normalized.toString().encodeUtf8()).sha256() }.hex()
-        val shaPath = (sha256.substring(0..1).toPath() / sha256).normalized()
+        val shaPath = mapExternalPath(normalized)
 
         delegate.createDirectories(shaPath.parent!!)
 


### PR DESCRIPTION
Originally, tests and code paths were expecting only NIX-style paths, this isn't correct on windows systems. Instead, tests now validate that both behave as expected (sha256 the path string) and verifies the result in an agnostic way outside of the single test