### PR TITLE
[Logical] Add Query pagination to RDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ hs_err_pid*
 
 # IDEA
 .idea/*.xml
+
+# Peazip
+.ptmp*

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
   api(Dependencies.RDF4J_MODEL_API)
+  api(Dependencies.RDF4J_QUERY)
 }

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/rdf/GraphQuerySafeExtensions.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/rdf/GraphQuerySafeExtensions.kt
@@ -1,0 +1,10 @@
+package com.github.nava2.aff4.model.rdf
+
+import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.query.GraphQuery
+
+fun GraphQuery.evaluateSequence(): Sequence<Statement> {
+  return sequence {
+    evaluate().use { yieldAll(it) }
+  }
+}

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/Aff4Model.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/Aff4Model.kt
@@ -2,22 +2,17 @@ package com.github.nava2.aff4.model
 
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
-import com.github.nava2.aff4.model.rdf.ZipVolume
 import java.io.Closeable
 import kotlin.reflect.KClass
 
 interface Aff4Model : Closeable {
   val containerContext: Aff4ImageContext
 
-  fun containerVolume(container: Aff4Container): ZipVolume?
-
-  fun <T : Aff4RdfModel> query(modelType: KClass<T>): List<T>
+  fun <T : Aff4RdfModel> query(modelType: KClass<T>): Sequence<T>
 
   fun <T : Aff4RdfModel> get(subject: Aff4Arn, modelType: KClass<T>): T
 
-  fun <T : Aff4RdfModel> getOrNull(subject: Aff4Arn, modelType: KClass<T>): T?
-
-  fun <T : Aff4RdfModel> querySubjectStartsWith(subjectPrefix: String, modelType: KClass<T>): List<T>
+  fun <T : Aff4RdfModel> querySubjectStartsWith(subjectPrefix: String, modelType: KClass<T>): Sequence<T>
 
   interface Loader {
     fun load(imageContext: Aff4ImageContext): Aff4Model
@@ -25,6 +20,9 @@ interface Aff4Model : Closeable {
 }
 
 inline fun <reified T : Aff4RdfModel> Aff4Model.get(subject: Aff4Arn): T = get(subject, T::class)
-inline fun <reified T : Aff4RdfModel> Aff4Model.getOrNull(subject: Aff4Arn): T? = getOrNull(subject, T::class)
 
-inline fun <reified T : Aff4RdfModel> Aff4Model.query(): List<T> = query(T::class)
+inline fun <reified T : Aff4RdfModel> Aff4Model.query(): Sequence<T> = query(T::class)
+
+inline fun <reified T : Aff4RdfModel> Aff4Model.querySubjectStartsWith(subjectPrefix: String): Sequence<T> {
+  return querySubjectStartsWith(subjectPrefix, T::class)
+}

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModels.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModels.kt
@@ -1,6 +1,7 @@
 package com.github.nava2.aff4.model.rdf
 
 import com.github.nava2.aff4.model.Aff4Model
+import com.github.nava2.aff4.model.querySubjectStartsWith
 import com.github.nava2.aff4.model.rdf.annotations.RdfModel
 import com.github.nava2.aff4.model.rdf.annotations.RdfValue
 import okio.Path
@@ -20,7 +21,7 @@ data class BlockHashes(
 @RdfModel("aff4:ZipVolume")
 data class ZipVolume(
   override val arn: Aff4Arn,
-  val contains: List<Resource> = listOf(),
+  val contains: Set<Resource> = setOf(),
   val creationTime: ZonedDateTime,
   @RdfValue("aff4:interface")
   val interfaceType: Resource, // todo this should be an enum?
@@ -63,11 +64,11 @@ data class ImageStream(
   val size: Long,
   val compressionMethod: CompressionMethod = CompressionMethod.None,
   @RdfValue("aff4:hash")
-  val linearHashes: List<Hash> = listOf(),
+  val linearHashes: Set<Hash> = setOf(),
   @RdfValue("aff4:imageStreamHash")
-  val imageStreamHashes: List<Hash> = listOf(),
+  val imageStreamHashes: Set<Hash> = setOf(),
   @RdfValue("aff4:imageStreamIndexHash")
-  val imageStreamIndexHashes: List<Hash> = listOf(),
+  val imageStreamIndexHashes: Set<Hash> = setOf(),
   override val stored: Aff4Arn,
   @RdfValue("aff4:target")
   val targets: Set<Aff4Arn> = setOf(),
@@ -93,7 +94,7 @@ data class ImageStream(
   }
 
   fun queryBlockHashes(aff4Model: Aff4Model): List<BlockHashes> {
-    return aff4Model.querySubjectStartsWith("$arn/blockhash.", BlockHashes::class)
+    return aff4Model.querySubjectStartsWith<BlockHashes>("$arn/blockhash.").toList()
   }
 }
 
@@ -164,7 +165,7 @@ data class ZipSegment(
   override val arn: Aff4Arn,
   val size: Long,
   @RdfValue("aff4:hash")
-  val linearHashes: List<Hash> = listOf(),
+  val linearHashes: Set<Hash> = setOf(),
   override val stored: Aff4Arn,
 ) : Aff4RdfBaseModels, StoredRdfModel {
   val segmentPath = arn.toAff4Path(stored)

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4ImageStreamSink.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4ImageStreamSink.kt
@@ -114,7 +114,9 @@ internal class Aff4ImageStreamSink @AssistedInject constructor(
 
     imageStream = imageStream.copy(
       size = dataPosition,
-      linearHashes = linearHashSinks.entries.map { (hashType, sink) -> hashType.value(sink.hash) },
+      linearHashes = linearHashSinks.entries.asSequence()
+        .map { (hashType, sink) -> hashType.value(sink.hash) }
+        .toSet(),
     )
   }
 

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/model/Aff4ModelBaseLinearTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/model/Aff4ModelBaseLinearTest.kt
@@ -15,6 +15,7 @@ import com.github.nava2.aff4.model.rdf.DiskImage
 import com.github.nava2.aff4.model.rdf.Hash
 import com.github.nava2.aff4.model.rdf.Image
 import com.github.nava2.aff4.model.rdf.ImageStream
+import com.github.nava2.aff4.model.rdf.MapStream
 import com.github.nava2.aff4.model.rdf.TimeStamps
 import com.github.nava2.aff4.model.rdf.ZipVolume
 import com.github.nava2.aff4.model.rdf.createArn
@@ -29,7 +30,6 @@ import org.eclipse.rdf4j.model.ValueFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
-import com.github.nava2.aff4.model.rdf.MapStream as AMap
 
 class Aff4ModelBaseLinearTest {
   @GuiceModule
@@ -73,7 +73,7 @@ class Aff4ModelBaseLinearTest {
         creationTime = parseZonedDateTime("2016-12-07T03:40:09.126Z"),
         interfaceType = aff4Type("Volume"),
         stored = "Base-Linear.aff4".toPath(),
-        contains = listOf(
+        contains = setOf(
           arn("aff4://c1a6ab35-d46a-4c37-9bfe-0b3e4f0f1ca3"),
           arn("aff4://c215ba20-5648-4209-a793-1f918c723610"),
           arn("aff4://c21070c3-6d57-4f3b-9276-f83b6bfed5ae"),
@@ -91,7 +91,7 @@ class Aff4ModelBaseLinearTest {
     val mapArn = arn("aff4://fcbfdce7-4488-4677-abf6-08bc931e195b")
     val imageStreamArn = arn("aff4://c215ba20-5648-4209-a793-1f918c723610")
 
-    assertThat(aff4Model.query(Image::class)).containsExactly(
+    assertThat(aff4Model.query<Image>().toSet()).containsExactly(
       Image(
         arn = diskImageArn,
         dataStreams = setOf(mapArn),
@@ -99,8 +99,8 @@ class Aff4ModelBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(AMap::class)).containsExactly(
-      AMap(
+    assertThat(aff4Model.query<MapStream>().toSet()).containsExactly(
+      MapStream(
         arn = mapArn,
         blockMapHash = Hash.Sha512(
           (
@@ -132,24 +132,24 @@ class Aff4ModelBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(ImageStream::class)).containsExactly(
+    assertThat(aff4Model.query<ImageStream>().toSet()).containsExactly(
       ImageStream(
         arn = imageStreamArn,
         chunkSize = 32768,
         chunksInSegment = 2048,
         size = 3964928,
         compressionMethod = snappyCompression,
-        linearHashes = listOf(
+        linearHashes = setOf(
           Hash.Sha1.decode("fbac22cca549310bc5df03b7560afcf490995fbb"),
           Hash.Md5.decode("d5825dc1152a42958c8219ff11ed01a3"),
         ),
-        imageStreamHashes = listOf(
+        imageStreamHashes = setOf(
           Hash.Sha512.decode(
             "7c909ad458a90ca083cf2d10848fb3aaee7d9ac008605f85aef1ac2db8249973ac7b6716f3250edb80219ff628d" +
               "6fb4873c33c59de0a3e6c7657e234e7ba0db3"
           ),
         ),
-        imageStreamIndexHashes = listOf(
+        imageStreamIndexHashes = setOf(
           Hash.Sha512.decode(
             "c663bc90d996d2c9699e00dc1ea2c55b3724f1eaca2b92119bb7c764aad222eed321cb00ee67899c027f6837a3bd" +
               "8f789a96adb6e9df51629b3cac0b6f9f0722"
@@ -161,7 +161,7 @@ class Aff4ModelBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(BlockHashes::class)).containsExactly(
+    assertThat(aff4Model.query<BlockHashes>().toSet()).containsExactly(
       BlockHashes(
         arn = arn("aff4://c215ba20-5648-4209-a793-1f918c723610/", "blockhash.md5"),
         hash = Hash.Sha512.decode(
@@ -182,7 +182,7 @@ class Aff4ModelBaseLinearTest {
   @Suppress("LongMethod")
   @Test
   fun `loads aff4 metadata`() {
-    assertThat(aff4Model.query(DiskImage::class)).containsExactly(
+    assertThat(aff4Model.query<DiskImage>().toSet()).containsExactly(
       DiskImage(
         arn = diskImageArn,
         size = 268435456L,
@@ -202,7 +202,7 @@ class Aff4ModelBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(CaseNotes::class)).containsExactlyInAnyOrder(
+    assertThat(aff4Model.query<CaseNotes>().toSet()).containsExactlyInAnyOrder(
       CaseNotes(
         arn = arn("aff4://427e2078-b010-462b-ba7c-f286b390ba94"),
         caseNumber = "Case ID: 1SR Canonical",
@@ -225,7 +225,7 @@ class Aff4ModelBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(CaseDetails::class)).containsExactly(
+    assertThat(aff4Model.query<CaseDetails>().toSet()).containsExactly(
       CaseDetails(
         arn = arn("aff4://c1a6ab35-d46a-4c37-9bfe-0b3e4f0f1ca3"),
         caseDescription = "Canonical Image Generation Test Case",
@@ -236,7 +236,7 @@ class Aff4ModelBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(TimeStamps::class)).containsExactly(
+    assertThat(aff4Model.query<TimeStamps>().toSet()).containsExactly(
       TimeStamps(
         arn = arn("aff4://db69295f-70c3-4e82-9530-a39507f1447b"),
         endTime = parseZonedDateTime("2016-12-07T03:40:09.28Z"),

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/model/Aff4ModelDreamTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/model/Aff4ModelDreamTest.kt
@@ -2,6 +2,7 @@ package com.github.nava2.aff4.model
 
 import com.github.nava2.aff4.Aff4ImageTestModule
 import com.github.nava2.aff4.UnderTest
+import com.github.nava2.aff4.io.decode
 import com.github.nava2.aff4.model.rdf.FileImage
 import com.github.nava2.aff4.model.rdf.Hash
 import com.github.nava2.aff4.model.rdf.ZipSegment
@@ -9,7 +10,6 @@ import com.github.nava2.aff4.model.rdf.createArn
 import com.github.nava2.aff4.parseZonedDateTime
 import com.github.nava2.aff4.satisfies
 import com.github.nava2.test.GuiceModule
-import okio.ByteString.Companion.decodeHex
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import org.assertj.core.api.Assertions.assertThat
@@ -46,7 +46,7 @@ class Aff4ModelDreamTest {
 
   @Test
   fun `loads files`() {
-    assertThat(aff4Model.query<FileImage>()).singleElement().isEqualTo(
+    assertThat(aff4Model.query<FileImage>().toSet()).singleElement().isEqualTo(
       FileImage(
         arn = arn("aff4://5aea2dd0-32b4-4c61-a9db-677654be6f83//test_images/AFF4-L/dream.txt"),
         originalFileName = "./test_images/AFF4-L/dream.txt".toPath(),
@@ -63,9 +63,9 @@ class Aff4ModelDreamTest {
       ZipSegment(
         arn = arn("aff4://5aea2dd0-32b4-4c61-a9db-677654be6f83//test_images/AFF4-L/dream.txt"),
         size = 8688,
-        linearHashes = listOf(
-          Hash.Md5("75d83773f8d431a3ca91bfb8859e486d".decodeHex()),
-          Hash.Sha1("9ae1b46bead70c322eef7ac8bc36a8ea2055595c".decodeHex()),
+        linearHashes = setOf(
+          Hash.Md5.decode("75d83773f8d431a3ca91bfb8859e486d"),
+          Hash.Sha1.decode("9ae1b46bead70c322eef7ac8bc36a8ea2055595c"),
         ),
         stored = arn("aff4://5aea2dd0-32b4-4c61-a9db-677654be6f83"),
       ),

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/model/Aff4ModelStripedBaseLinearTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/model/Aff4ModelStripedBaseLinearTest.kt
@@ -73,7 +73,7 @@ class Aff4ModelStripedBaseLinearTest {
         creationTime = parseZonedDateTime("2016-12-07T03:40:12.185Z"),
         interfaceType = aff4Type("Volume"),
         stored = "Base-Linear_1.aff4".toPath(),
-        contains = listOf(
+        contains = setOf(
           arn("aff4://1311a313-e27a-4756-8bb5-22c984061270"),
           arn("aff4://a04a9189-5e92-4024-a577-37d6cfa72594"),
           arn("aff4://2dd04819-73c8-40e3-a32b-fdddb0317eac"),
@@ -88,7 +88,7 @@ class Aff4ModelStripedBaseLinearTest {
         creationTime = parseZonedDateTime("2016-12-07T03:40:12.185Z"),
         interfaceType = aff4Type("Volume"),
         stored = "Base-Linear_2.aff4".toPath(),
-        contains = listOf(
+        contains = setOf(
           arn("aff4://363ac10c-8d8d-4905-ac25-a14aaddd8a41"),
           arn("aff4://b33a5803-ef89-4463-94ce-f265ec7eb9f1"),
           arn("aff4://951b3e29-6549-4266-8e81-3f88ddba61ae"),
@@ -100,7 +100,7 @@ class Aff4ModelStripedBaseLinearTest {
       ),
     ).associateBy { it.arn }
 
-    assertThat(aff4Model.query<ZipVolume>()).allSatisfy { zipVolume ->
+    assertThat(aff4Model.query<ZipVolume>().toSet()).allSatisfy { zipVolume ->
       val expectedZipVolume = expectedZipVolumes.getValue(zipVolume.arn)
       assertThat(zipVolume).isEqualTo(expectedZipVolume)
     }
@@ -109,7 +109,7 @@ class Aff4ModelStripedBaseLinearTest {
   @Suppress("LongMethod")
   @Test
   fun `loads images`() {
-    assertThat(aff4Model.query(Image::class)).containsExactly(
+    assertThat(aff4Model.query<Image>().toSet()).containsExactly(
       Image(
         arn = diskImageArn,
         dataStreams = setOf(
@@ -185,26 +185,26 @@ class Aff4ModelStripedBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query<MapStream>()).containsExactlyInAnyOrderElementsOf(expectedMapStreams)
+    assertThat(aff4Model.query<MapStream>().toSet()).containsExactlyInAnyOrderElementsOf(expectedMapStreams)
 
-    assertThat(aff4Model.query<ImageStream>()).containsExactlyInAnyOrder(
+    assertThat(aff4Model.query<ImageStream>().toSet()).containsExactlyInAnyOrder(
       ImageStream(
         arn = arn("aff4://3bf0bd14-1ef9-4185-8b0a-2c7d511b4d30"),
         chunkSize = 32768,
         chunksInSegment = 2048,
         size = 1966080,
         compressionMethod = snappyCompression,
-        linearHashes = listOf(
+        linearHashes = setOf(
           Hash.Sha1.decode("5d14518149402e3935930b389564c9dc8c674fd1"),
           Hash.Md5.decode("8eaf5dd1e12e4dd8cc9c68be51660e4d"),
         ),
-        imageStreamHashes = listOf(
+        imageStreamHashes = setOf(
           Hash.Sha512.decode(
             "30dfba8269539ee364361d17b4518c32cd367079aa99ff7ee96918ec027ecbceff1334f1f2" +
               "ed2f1046ef433c6ceaf644b7dd55401e7dda46ad1393be73ee24a8"
           ),
         ),
-        imageStreamIndexHashes = listOf(
+        imageStreamIndexHashes = setOf(
           Hash.Sha512.decode(
             "09a5148b36ac629eb48af0f60263a7dcb81e186908b50544561954acd32810f94a19554d5f9" +
               "06363079a03e4186ee9fe73860fbd0e87a2e55a31dc1dafd79e07"
@@ -220,17 +220,17 @@ class Aff4ModelStripedBaseLinearTest {
         chunksInSegment = 2048,
         size = 1998848,
         compressionMethod = snappyCompression,
-        linearHashes = listOf(
+        linearHashes = setOf(
           Hash.Sha1.decode("00412c53666cd74c81d5703c77d865145dde1082"),
           Hash.Md5.decode("b20122bc5e70fafb582820a25f895646"),
         ),
-        imageStreamHashes = listOf(
+        imageStreamHashes = setOf(
           Hash.Sha512.decode(
             "574e12d53b6a609ad7340cbd7359243fe058876381cd82d6357da19052ed89007aa6e2e635" +
               "87ef8605c9de41691cd12689257e513af8c30a6777f6840c6d76b7"
           ),
         ),
-        imageStreamIndexHashes = listOf(
+        imageStreamIndexHashes = setOf(
           Hash.Sha512.decode(
             "2364325d0822af6bbd5221813ac04d957f39c652de4a8151ebd8bea4b571f1a5f2dde0ba7a2" +
               "dc274a936705b2e08dc9d6d957cf24ba7e7304cdd5e8aa19a8127"
@@ -242,7 +242,7 @@ class Aff4ModelStripedBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(BlockHashes::class)).containsExactlyInAnyOrder(
+    assertThat(aff4Model.query<BlockHashes>().toSet()).containsExactlyInAnyOrder(
       BlockHashes(
         arn = arn("aff4://a04a9189-5e92-4024-a577-37d6cfa72594/", "blockhash.md5"),
         hash = Hash.Sha512.decode(
@@ -277,7 +277,7 @@ class Aff4ModelStripedBaseLinearTest {
   @Suppress("LongMethod")
   @Test
   fun `loads aff4 metadata`() {
-    assertThat(aff4Model.query(DiskImage::class)).containsExactly(
+    assertThat(aff4Model.query<DiskImage>().toSet()).containsExactly(
       DiskImage(
         arn = diskImageArn,
         size = 268435456L,
@@ -297,7 +297,7 @@ class Aff4ModelStripedBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(CaseNotes::class)).containsExactlyInAnyOrder(
+    assertThat(aff4Model.query<CaseNotes>().toSet()).containsExactlyInAnyOrder(
       CaseNotes(
         arn = arn("aff4://a393456b-1c6f-48f2-aefd-45157d997493"),
         caseNumber = "Case ID: 1SR Canonical",
@@ -320,7 +320,7 @@ class Aff4ModelStripedBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(CaseDetails::class)).containsExactly(
+    assertThat(aff4Model.query<CaseDetails>().toSet()).containsExactly(
       CaseDetails(
         arn = arn("aff4://0adda6d6-97c5-4842-8981-dec2a3373215"),
         caseDescription = "Canonical Image Generation Test Case",
@@ -331,7 +331,7 @@ class Aff4ModelStripedBaseLinearTest {
       ),
     )
 
-    assertThat(aff4Model.query(TimeStamps::class)).containsExactly(
+    assertThat(aff4Model.query<TimeStamps>().toSet()).containsExactly(
       TimeStamps(
         arn = arn("aff4://1311a313-e27a-4756-8bb5-22c984061270"),
         startTime = parseZonedDateTime("2016-12-07T03:40:12.190Z"),

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4ImageStreamSinkTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4ImageStreamSinkTest.kt
@@ -4,10 +4,12 @@ import com.github.nava2.aff4.Aff4BaseStreamModule
 import com.github.nava2.aff4.UsingTemporary
 import com.github.nava2.aff4.container.Aff4ContainerBuilder
 import com.github.nava2.aff4.container.RealAff4ContainerBuilder
+import com.github.nava2.aff4.io.decode
 import com.github.nava2.aff4.io.repeatByteString
 import com.github.nava2.aff4.model.Aff4ImageOpener
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.CompressionMethod
+import com.github.nava2.aff4.model.rdf.Hash
 import com.github.nava2.aff4.model.rdf.HashType
 import com.github.nava2.aff4.model.rdf.ImageStream
 import com.github.nava2.aff4.model.rdf.None
@@ -19,7 +21,6 @@ import com.github.nava2.aff4.streams.compression.SnappyCompression
 import com.github.nava2.test.GuiceModule
 import okio.Buffer
 import okio.ByteString
-import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -93,7 +94,7 @@ class Aff4ImageStreamSinkTest {
       size = Long.MAX_VALUE,
       compressionMethod = CompressionMethod.None,
       stored = containerArn,
-      linearHashes = listOf(HashType.SHA256, HashType.MD5).map { it.value(ByteString.EMPTY) },
+      linearHashes = listOf(HashType.SHA256, HashType.MD5).map { it.value(ByteString.EMPTY) }.toSet(),
     )
 
     val content = "abcdefghijklmno".encodeUtf8()
@@ -105,16 +106,14 @@ class Aff4ImageStreamSinkTest {
         imageStreamSink.imageStream
       }
 
-    val md5LinearHash = HashType.MD5.value("8a7319dbf6544a7422c9e25452580ea5".decodeHex())
-    val sha256LinearHash = HashType.SHA256.value(
-      "41c7760c50efde99bf574ed8fffc7a6dd3405d546d3da929b214c8945acf8a97".decodeHex(),
-    )
+    val md5LinearHash = Hash.Md5.decode("8a7319dbf6544a7422c9e25452580ea5")
+    val sha256LinearHash = Hash.Sha256.decode("41c7760c50efde99bf574ed8fffc7a6dd3405d546d3da929b214c8945acf8a97")
 
     assertThat(writtenImageStream)
       .isEqualTo(
         imageStream.copy(
           size = content.size.toLong(),
-          linearHashes = listOf(sha256LinearHash, md5LinearHash),
+          linearHashes = setOf(sha256LinearHash, md5LinearHash),
         )
       )
 
@@ -132,7 +131,7 @@ class Aff4ImageStreamSinkTest {
       size = Long.MAX_VALUE,
       compressionMethod = CompressionMethod.None,
       stored = containerArn,
-      linearHashes = listOf(HashType.SHA256, HashType.MD5).map { it.value(ByteString.EMPTY) },
+      linearHashes = listOf(HashType.SHA256, HashType.MD5).map { it.value(ByteString.EMPTY) }.toSet(),
     )
 
     val content = "abcdefghijklmno".encodeUtf8()
@@ -152,16 +151,14 @@ class Aff4ImageStreamSinkTest {
         imageStreamSink.imageStream
       }
 
-    val md5LinearHash = HashType.MD5.value("8a7319dbf6544a7422c9e25452580ea5".decodeHex())
-    val sha256LinearHash = HashType.SHA256.value(
-      "41c7760c50efde99bf574ed8fffc7a6dd3405d546d3da929b214c8945acf8a97".decodeHex(),
-    )
+    val md5LinearHash = Hash.Md5.decode("8a7319dbf6544a7422c9e25452580ea5")
+    val sha256LinearHash = Hash.Sha256.decode("41c7760c50efde99bf574ed8fffc7a6dd3405d546d3da929b214c8945acf8a97")
 
     assertThat(writtenImageStream)
       .isEqualTo(
         imageStream.copy(
           size = content.size.toLong(),
-          linearHashes = listOf(sha256LinearHash, md5LinearHash),
+          linearHashes = setOf(sha256LinearHash, md5LinearHash),
         )
       )
 
@@ -181,7 +178,7 @@ class Aff4ImageStreamSinkTest {
       size = content.size.toLong(),
       compressionMethod = snappyCompression,
       stored = aff4ContainerBuilder.containerArn,
-      linearHashes = listOf(HashType.SHA256, HashType.MD5).map { it.value(ByteString.EMPTY) },
+      linearHashes = listOf(HashType.SHA256, HashType.MD5).map { it.value(ByteString.EMPTY) }.toSet(),
     )
 
     val writtenImageStream = aff4ContainerBuilder.createImageStream(imageStream, listOf())
@@ -191,17 +188,15 @@ class Aff4ImageStreamSinkTest {
         imageStreamSink.imageStream
       }
 
-    val md5LinearHash = HashType.MD5.value("6d0bb00954ceb7fbee436bb55a8397a9".decodeHex())
-    val sha256LinearHash = HashType.SHA256.value(
-      "cd00e292c5970d3c5e2f0ffa5171e555bc46bfc4faddfb4a418b6840b86e79a3".decodeHex(),
-    )
+    val md5LinearHash = Hash.Md5.decode("6d0bb00954ceb7fbee436bb55a8397a9")
+    val sha256LinearHash = Hash.Sha256.decode("cd00e292c5970d3c5e2f0ffa5171e555bc46bfc4faddfb4a418b6840b86e79a3")
 
     assertThat(writtenImageStream)
       .usingRecursiveComparison()
       .isEqualTo(
         imageStream.copy(
           size = content.size.toLong(),
-          linearHashes = listOf(sha256LinearHash, md5LinearHash),
+          linearHashes = setOf(sha256LinearHash, md5LinearHash),
         )
       )
 

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/Aff4MapStreamSinkTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/Aff4MapStreamSinkTest.kt
@@ -104,7 +104,7 @@ class Aff4MapStreamSinkTest {
       size = Long.MAX_VALUE,
       compressionMethod = CompressionMethod.None,
       stored = containerArn,
-      linearHashes = listOf(HashType.MD5).map { it.value(ByteString.EMPTY) },
+      linearHashes = listOf(HashType.MD5).map { it.value(ByteString.EMPTY) }.toSet(),
     )
 
     val mapStream = MapStream(
@@ -242,7 +242,7 @@ class Aff4MapStreamSinkTest {
       size = Long.MAX_VALUE,
       compressionMethod = CompressionMethod.None,
       stored = containerArn,
-      linearHashes = listOf(HashType.MD5).map { it.value(ByteString.EMPTY) },
+      linearHashes = listOf(HashType.MD5).map { it.value(ByteString.EMPTY) }.toSet(),
     )
 
     val mapStream = MapStream(
@@ -346,7 +346,7 @@ class Aff4MapStreamSinkTest {
       size = Long.MAX_VALUE,
       compressionMethod = snappyCompression,
       stored = containerArn,
-      linearHashes = listOf(HashType.MD5).map { it.value(ByteString.EMPTY) },
+      linearHashes = listOf(HashType.MD5).map { it.value(ByteString.EMPTY) }.toSet(),
     )
 
     val mapStream = MapStream(

--- a/aff4/aff4-reader/src/main/kotlin/com/github/nava2/aff4/Verify.kt
+++ b/aff4/aff4-reader/src/main/kotlin/com/github/nava2/aff4/Verify.kt
@@ -64,7 +64,7 @@ class Verify : Subcommand("verify", "Verify an image") {
       logger.debug("Opened image, querying streams")
 
       val model = container.aff4Model
-      val streams = model.query<ImageStream>() + model.query<MapStream>() + model.query<ZipSegment>()
+      val streams = (model.query<ImageStream>() + model.query<MapStream>() + model.query<ZipSegment>()).toList()
 
       logger.info("Verifying ${streams.size} streams")
       logger.debug("Verifying [${streams.size}] = [\n\t${streams.joinToString("\n\t")}\n]")


### PR DESCRIPTION
In order to list files, we need to do large queries against the RDF store. These can be very large queries and we need to be mindful to only query what we need.

This also strips out some unused methods from the APIs. 

Follow-up: Replace the usage of `Model` with some form of queries where a connection is opened, utilized then closed. The current approach leads to awkward usages where we open too many connections needlessly. 