### PR TITLE
Add `ToolDialect` and `DefaultToolDialect` for standard definition

### DIFF
--- a/aff4/aff4-core/aff4-core-guice/src/main/kotlin/com/github/nava2/guice/KAbstractModule.kt
+++ b/aff4/aff4-core/aff4-core-guice/src/main/kotlin/com/github/nava2/guice/KAbstractModule.kt
@@ -20,6 +20,10 @@ abstract class KAbstractModule protected constructor() : AbstractModule() {
     return requireBinding(T::class.java)
   }
 
+  protected inline fun <reified T> requireBinding(annotatedWith: KClass<out Annotation>) {
+    return requireBinding(key<T>(annotatedWith))
+  }
+
   protected inline fun <reified T> bindSet(
     block: KSetMultibinderHelper<T>.() -> Unit
   ): Multibinder<T> {

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/build.gradle.kts
@@ -1,8 +1,11 @@
 dependencies {
   api(Dependencies.GUAVA)
+  api(Dependencies.GUICE)
   api(Dependencies.OKIO)
   api(Dependencies.RDF4J_MODEL_API)
   api(Dependencies.RDF4J_QUERY)
+
+  api(project(":aff4:aff4-core:aff4-core-guice"))
 
   implementation(kotlin("reflect"))
 }

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/Aff4ToolDialectModule.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/Aff4ToolDialectModule.kt
@@ -1,0 +1,11 @@
+package com.github.nava2.aff4.model.dialect
+
+import com.github.nava2.guice.KAbstractModule
+
+object Aff4ToolDialectModule : KAbstractModule() {
+  override fun configure() {
+    requireBinding<ToolDialect>(DefaultToolDialect::class)
+
+    bindSet<ToolDialect> { }
+  }
+}

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/DefaultToolDialect.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/DefaultToolDialect.kt
@@ -1,0 +1,15 @@
+package com.github.nava2.aff4.model.dialect
+
+import com.google.inject.BindingAnnotation
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FIELD
+import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
+import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
+
+/**
+ * Used to define the default implementation for [ToolDialect]. This is used if no other specialty ones apply.
+ */
+@Target(VALUE_PARAMETER, PROPERTY_SETTER, FIELD)
+@Retention(RUNTIME)
+@BindingAnnotation
+annotation class DefaultToolDialect

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/ToolDialect.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/ToolDialect.kt
@@ -1,0 +1,12 @@
+package com.github.nava2.aff4.model.dialect
+
+import com.github.nava2.aff4.model.Aff4Container
+
+interface ToolDialect {
+  val typeResolver: DialectTypeResolver
+
+  /**
+   * Returns true if this dialect applies to the tool
+   */
+  fun isApplicable(toolMetadata: Aff4Container.ToolMetadata): Boolean
+}

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/Aff4LogicalStandardToolDialect.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/Aff4LogicalStandardToolDialect.kt
@@ -1,0 +1,21 @@
+package com.github.nava2.aff4.model
+
+import com.github.nava2.aff4.model.dialect.DialectTypeResolver
+import com.github.nava2.aff4.model.dialect.ToolDialect
+import javax.inject.Singleton
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+
+@Singleton
+internal class Aff4LogicalStandardToolDialect(
+  override val typeResolver: DialectTypeResolver,
+) : ToolDialect {
+
+  override fun isApplicable(toolMetadata: Aff4Container.ToolMetadata): Boolean {
+    return true
+  }
+
+  @Target(CLASS)
+  @Retention(RUNTIME)
+  annotation class RdfStandardType(val rdfType: String)
+}

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModelPlugin.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModelPlugin.kt
@@ -1,9 +1,25 @@
 package com.github.nava2.aff4.model.rdf
 
+import com.github.nava2.aff4.model.Aff4LogicalStandardToolDialect
+import com.github.nava2.aff4.model.Aff4LogicalStandardToolDialect.RdfStandardType
+import com.github.nava2.aff4.model.dialect.Aff4ToolDialectModule
+import com.github.nava2.aff4.model.dialect.DefaultToolDialect
+import com.github.nava2.aff4.model.dialect.DialectTypeResolver
+import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.plugins.KAff4Plugin
+import com.github.nava2.guice.key
+import com.github.nava2.guice.to
+import com.google.inject.Provides
+import javax.inject.Singleton
+import kotlin.reflect.KClass
 
 object Aff4RdfModelPlugin : KAff4Plugin(pluginIdentifier = "kaff4:aff4-rdf-models") {
   override fun configurePlugin() {
+    install(Aff4ToolDialectModule)
+
+    bind(key<ToolDialect>(DefaultToolDialect::class))
+      .to<Aff4LogicalStandardToolDialect>()
+
     bindAff4Models {
       for (subclass in Aff4RdfBaseModels::class.sealedSubclasses) {
         toInstance(subclass)
@@ -15,5 +31,23 @@ object Aff4RdfModelPlugin : KAff4Plugin(pluginIdentifier = "kaff4:aff4-rdf-model
       to<Aff4HashRdfValueConverter>()
       to<Aff4CompressionMethodValueConverter>()
     }
+  }
+
+  @Singleton
+  @Provides
+  internal fun providesAff4LogicalStandardDialect(
+    modelKlasses: Set<KClass<out Aff4RdfModel>>,
+  ): Aff4LogicalStandardToolDialect {
+    val typeResolver = DialectTypeResolver.Builder.forAnnotation(RdfStandardType::class) {
+      rdfType to setOf(rdfType)
+    }
+      .apply {
+        for (modelKlass in modelKlasses) {
+          register(modelKlass)
+        }
+      }
+      .build()
+
+    return Aff4LogicalStandardToolDialect(typeResolver)
   }
 }

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModels.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModels.kt
@@ -1,5 +1,6 @@
 package com.github.nava2.aff4.model.rdf
 
+import com.github.nava2.aff4.model.Aff4LogicalStandardToolDialect.RdfStandardType
 import com.github.nava2.aff4.model.Aff4Model
 import com.github.nava2.aff4.model.querySubjectStartsWith
 import com.github.nava2.aff4.model.rdf.annotations.RdfModel
@@ -11,6 +12,7 @@ import java.time.ZonedDateTime
 sealed interface Aff4RdfBaseModels : Aff4RdfModel
 
 @RdfModel("aff4:BlockHashes")
+@RdfStandardType("aff4:BlockHashes")
 data class BlockHashes(
   override val arn: Aff4Arn,
   val hash: Hash,
@@ -19,6 +21,7 @@ data class BlockHashes(
 }
 
 @RdfModel("aff4:ZipVolume")
+@RdfStandardType("aff4:ZipVolume")
 data class ZipVolume(
   override val arn: Aff4Arn,
   val contains: Set<Resource> = setOf(),
@@ -29,6 +32,7 @@ data class ZipVolume(
 ) : Aff4RdfBaseModels
 
 @RdfModel("aff4:Map")
+@RdfStandardType("aff4:Map")
 data class MapStream(
   override val arn: Aff4Arn,
   @RdfValue("aff4:dependentStream")
@@ -49,6 +53,7 @@ data class MapStream(
 }
 
 @RdfModel("aff4:Image")
+@RdfStandardType("aff4:Image")
 data class Image(
   override val arn: Aff4Arn,
   @RdfValue("aff4:dataStream")
@@ -57,6 +62,7 @@ data class Image(
 ) : Aff4RdfBaseModels
 
 @RdfModel("aff4:ImageStream")
+@RdfStandardType("aff4:ImageStream")
 data class ImageStream(
   override val arn: Aff4Arn,
   val chunkSize: Int,
@@ -99,6 +105,7 @@ data class ImageStream(
 }
 
 @RdfModel("aff4:CaseNotes")
+@RdfStandardType("aff4:CaseNotes")
 data class CaseNotes(
   override val arn: Aff4Arn,
   val caseNumber: String? = null,
@@ -111,6 +118,7 @@ data class CaseNotes(
 ) : Aff4RdfBaseModels
 
 @RdfModel("aff4:CaseDetails")
+@RdfStandardType("aff4:CaseDetails")
 data class CaseDetails(
   override val arn: Aff4Arn,
   val caseDescription: String? = null,
@@ -131,6 +139,7 @@ enum class Aff4TimeSource {
 }
 
 @RdfModel("aff4:TimeStamps")
+@RdfStandardType("aff4:TimeStamps")
 data class TimeStamps(
   override val arn: Aff4Arn,
   val endTime: ZonedDateTime,
@@ -142,6 +151,7 @@ data class TimeStamps(
 ) : Aff4RdfBaseModels
 
 @RdfModel("aff4:DiskImage")
+@RdfStandardType("aff4:DiskImage")
 data class DiskImage(
   override val arn: Aff4Arn,
   val size: Long,
@@ -161,6 +171,7 @@ data class DiskImage(
 ) : Aff4RdfBaseModels
 
 @RdfModel("aff4:ZipSegment", "aff4:zip_segment")
+@RdfStandardType("aff4:ZipSegment")
 data class ZipSegment(
   override val arn: Aff4Arn,
   val size: Long,
@@ -172,6 +183,7 @@ data class ZipSegment(
 }
 
 @RdfModel("aff4:FileImage")
+@RdfStandardType("aff4:FileImage")
 data class FileImage(
   override val arn: Aff4Arn,
   val originalFileName: Path,

--- a/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/Aff4LogicalStandardToolDialectTest.kt
+++ b/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/Aff4LogicalStandardToolDialectTest.kt
@@ -1,0 +1,86 @@
+package com.github.nava2.aff4.model
+
+import com.github.nava2.aff4.Aff4TestModule
+import com.github.nava2.aff4.model.dialect.DefaultToolDialect
+import com.github.nava2.aff4.model.dialect.ToolDialect
+import com.github.nava2.aff4.model.rdf.FileImage
+import com.github.nava2.aff4.model.rdf.ImageStream
+import com.github.nava2.aff4.model.rdf.MapStream
+import com.github.nava2.aff4.model.rdf.TurtleIri
+import com.github.nava2.aff4.model.rdf.ZipSegment
+import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.test.GuiceModule
+import com.google.inject.util.Modules
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal class Aff4LogicalStandardToolDialectTest {
+  @GuiceModule
+  val module = Modules.combine(
+    Aff4TestModule,
+    object : KAbstractModule() {
+      override fun configure() {
+        bind<ValueFactory>().toInstance(SimpleValueFactory.getInstance())
+      }
+    }
+  )
+
+  @Inject
+  private lateinit var aff4LogicalStandardToolDialect: Aff4LogicalStandardToolDialect
+
+  @Inject
+  @field:DefaultToolDialect
+  private lateinit var defaultToolDialectProvider: Provider<ToolDialect>
+
+  @Inject
+  private lateinit var toolDialectsProvider: Provider<Set<ToolDialect>>
+
+  @Test
+  fun `verify correctly maps streams`() {
+    val typeResolver = aff4LogicalStandardToolDialect.typeResolver
+
+    assertThat(
+      listOf(
+        MapStream::class to TurtleIri("aff4:Map"),
+        ImageStream::class to TurtleIri("aff4:ImageStream"),
+        ZipSegment::class to TurtleIri("aff4:ZipSegment"),
+        FileImage::class to TurtleIri("aff4:FileImage"),
+      )
+    ).allSatisfy { (klass, iri) ->
+      assertThat(typeResolver[klass]).isEqualTo(iri)
+      assertThat(typeResolver[iri]).isEqualTo(klass)
+    }
+  }
+
+  @Test
+  fun `logical standard is always applicable`() {
+    val metadatas = listOf(
+      Aff4Container.ToolMetadata("foo", "bar"),
+      Aff4Container.ToolMetadata("1.0", "pyaff4"),
+      Aff4Container.ToolMetadata("0.0.0.04", "definitely-fake"),
+    )
+
+    assertThat(metadatas).allSatisfy { metadata ->
+      assertThat(aff4LogicalStandardToolDialect.isApplicable(metadata)).isTrue()
+    }
+  }
+
+  @Test
+  fun `@DefaultToolDialect is mapped to Aff4LogicalStandardToolDialect and singleton`() {
+    assertThat(defaultToolDialectProvider.get())
+      // mapped to logical
+      .isSameAs(aff4LogicalStandardToolDialect)
+      // singleton
+      .isSameAs(defaultToolDialectProvider.get())
+  }
+
+  @Test
+  fun `Aff4LogicalStandardToolDialect is not injected with other ToolDialect`() {
+    assertThat(toolDialectsProvider.get())
+      .doesNotContain(aff4LogicalStandardToolDialect)
+  }
+}

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/Aff4TestModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/Aff4TestModule.kt
@@ -1,6 +1,7 @@
 package com.github.nava2.aff4
 
 import com.github.nava2.aff4.io.relativeTo
+import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
 import com.github.nava2.aff4.rdf.MemoryRdfRepositoryPlugin
 import com.github.nava2.guice.KAbstractModule
 import com.google.inject.Provides
@@ -16,6 +17,7 @@ object Aff4TestModule : KAbstractModule() {
 
     install(TestRandomsModule)
     install(MemoryRdfRepositoryPlugin)
+    install(Aff4RdfModelPlugin)
   }
 
   @Provides


### PR DESCRIPTION
This adds a `ToolDialect` system for computing and registering behaviour that changes how the library parses different images.

This is necessitated due to defects, changes to standards, and general quirks with implementations that write AFF4 images. By leveraging these dialects, we can isolate these behaviours in a consistent way and allow the library to adjust how it parses and reads these images.

This adds an `Aff4LogicalStandardToolDialect` which behaves as the `DefaultToolDialect` when none can be detected formally.

Extracted from #37