### PR TITLE
[RDF] Pull `TurtleIri` through all places that used `String` for `Iri`…

### DIFF
--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolver.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolver.kt
@@ -2,6 +2,7 @@ package com.github.nava2.aff4.model.dialect
 
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
 import com.github.nava2.aff4.model.rdf.TurtleIri
+import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import com.google.common.collect.ArrayListMultimap
 import com.google.common.collect.ImmutableListMultimap
 import com.google.common.collect.ImmutableMap
@@ -98,7 +99,7 @@ interface DialectTypeResolver {
       primaryValue: String,
       vararg additionalValues: String,
     ): SimpleBuilder {
-      return register(klass, TurtleIri(primaryValue), additionalValues.map { TurtleIri(it) })
+      return register(klass, primaryValue.toTurtleIri(), additionalValues.map { it.toTurtleIri() })
     }
 
     operator fun set(klass: KClass<*>, value: String): SimpleBuilder {
@@ -121,7 +122,7 @@ interface DialectTypeResolver {
         "Can not register $klass without $annotationKlass present"
       }
       val (primaryIri, synonyms) = annotation.extractor()
-      register(klass, TurtleIri(primaryIri), synonyms.map { TurtleIri(it) })
+      register(klass, primaryIri.toTurtleIri(), synonyms.map { it.toTurtleIri() })
       return this
     }
 

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/rdf/TurtleIri.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/rdf/TurtleIri.kt
@@ -1,4 +1,25 @@
 package com.github.nava2.aff4.model.rdf
 
 @JvmInline
-value class TurtleIri(val iri: String)
+value class TurtleIri private constructor(val iri: String) {
+  init {
+    val index = iri.indexOf(':', startIndex = 1)
+    check(index in (0 until iri.lastIndex)) {
+      "Must use valid IRI syntax for Turtle: \$NAMESPACE:\$LOCAL_NAME (e.g. aff4:Image)"
+    }
+  }
+
+  val namespace: String
+    get() = iri.substringBefore(':')
+  operator fun component1(): String = namespace
+
+  val localName: String
+    get() = iri.substringAfter(':')
+  operator fun component2(): String = localName
+
+  companion object {
+    val RDF_TYPE = "rdf:type".toTurtleIri()
+
+    fun String.toTurtleIri() = TurtleIri(this)
+  }
+}

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/rdf/annotations/RdfModel.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/rdf/annotations/RdfModel.kt
@@ -1,5 +1,8 @@
 package com.github.nava2.aff4.model.rdf.annotations
 
+import com.github.nava2.aff4.model.rdf.TurtleIri
+import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
+
 /**
  * Defines the [rdfType] of an [Aff4Model] type.
  */
@@ -16,12 +19,12 @@ annotation class RdfModel(
   vararg val synonyms: String,
 )
 
-val RdfModel.allRdfTypes: Set<String>
+val RdfModel.allRdfTypes: Set<TurtleIri>
   get() = if (synonyms.isEmpty()) {
-    setOf(rdfType)
+    setOf(rdfType.toTurtleIri())
   } else {
     buildSet {
-      add(rdfType)
-      addAll(synonyms)
+      add(rdfType.toTurtleIri())
+      addAll(synonyms.asSequence().map { it.toTurtleIri() })
     }
   }

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/test/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolverTest.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/test/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolverTest.kt
@@ -2,9 +2,10 @@ package com.github.nava2.aff4.model.dialect
 
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
-import com.github.nava2.aff4.model.rdf.TurtleIri
+import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 
 internal class DialectTypeResolverTest {
   @Test
@@ -12,7 +13,7 @@ internal class DialectTypeResolverTest {
     val typeResolver = DialectTypeResolver.Builder.empty().build()
 
     assertThat(typeResolver[SimpleModel::class]).isNull()
-    assertThat(typeResolver[TurtleIri(SIMPLE_IRI)]).isNull()
+    assertThat(typeResolver[SIMPLE_IRI]).isNull()
   }
 
   @Test
@@ -21,11 +22,11 @@ internal class DialectTypeResolverTest {
       .register(SimpleModel::class, SIMPLE_IRI)
       .build()
 
-    assertThat(typeResolver[SimpleModel::class]).isEqualTo(TurtleIri(SIMPLE_IRI))
-    assertThat(typeResolver[TurtleIri(SIMPLE_IRI)]).isEqualTo(SimpleModel::class)
+    assertThat(typeResolver[SimpleModel::class]).isEqualTo(SIMPLE_IRI.toTurtleIri())
+    assertThat(typeResolver[SIMPLE_IRI]).isEqualTo(SimpleModel::class)
 
     assertThat(typeResolver[AnotherSimpleModel::class]).isNull()
-    assertThat(typeResolver[TurtleIri(ANOTHER_IRI)]).isNull()
+    assertThat(typeResolver[ANOTHER_IRI]).isNull()
   }
 
   @Test
@@ -34,12 +35,12 @@ internal class DialectTypeResolverTest {
       .register(SimpleModel::class, SIMPLE_IRI, SIMPLE_2_IRI)
       .build()
 
-    assertThat(typeResolver[SimpleModel::class]).isEqualTo(TurtleIri(SIMPLE_IRI))
-    assertThat(typeResolver[TurtleIri(SIMPLE_IRI)]).isEqualTo(SimpleModel::class)
-    assertThat(typeResolver[TurtleIri(SIMPLE_2_IRI)]).isEqualTo(SimpleModel::class)
+    assertThat(typeResolver[SimpleModel::class]).isEqualTo(SIMPLE_IRI.toTurtleIri())
+    assertThat(typeResolver[SIMPLE_IRI]).isEqualTo(SimpleModel::class)
+    assertThat(typeResolver[SIMPLE_2_IRI]).isEqualTo(SimpleModel::class)
 
     assertThat(typeResolver[AnotherSimpleModel::class]).isNull()
-    assertThat(typeResolver[TurtleIri(ANOTHER_IRI)]).isNull()
+    assertThat(typeResolver[ANOTHER_IRI]).isNull()
   }
 
   @Test
@@ -51,12 +52,12 @@ internal class DialectTypeResolverTest {
       .register<AnotherSimpleModel>()
       .build()
 
-    assertThat(typeResolver[SimpleModel::class]).isEqualTo(TurtleIri(SIMPLE_IRI))
-    assertThat(typeResolver[TurtleIri(SIMPLE_IRI)]).isEqualTo(SimpleModel::class)
-    assertThat(typeResolver[TurtleIri(SIMPLE_2_IRI)]).isEqualTo(SimpleModel::class)
+    assertThat(typeResolver[SimpleModel::class]).isEqualTo(SIMPLE_IRI.toTurtleIri())
+    assertThat(typeResolver[SIMPLE_IRI]).isEqualTo(SimpleModel::class)
+    assertThat(typeResolver[SIMPLE_2_IRI]).isEqualTo(SimpleModel::class)
 
-    assertThat(typeResolver[AnotherSimpleModel::class]).isEqualTo(TurtleIri(ANOTHER_IRI))
-    assertThat(typeResolver[TurtleIri(ANOTHER_IRI)]).isEqualTo(AnotherSimpleModel::class)
+    assertThat(typeResolver[AnotherSimpleModel::class]).isEqualTo(ANOTHER_IRI.toTurtleIri())
+    assertThat(typeResolver[ANOTHER_IRI]).isEqualTo(AnotherSimpleModel::class)
   }
 }
 
@@ -74,3 +75,5 @@ private data class AnotherSimpleModel(override val arn: Aff4Arn) : Aff4RdfModel
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class TestRdfModel(val primaryType: String, vararg val rdfTypes: String)
+
+private operator fun DialectTypeResolver.get(iri: String): KClass<*>? = get(iri.toTurtleIri())

--- a/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
+++ b/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
@@ -5,7 +5,7 @@ import com.github.nava2.aff4.model.Aff4Container
 import com.github.nava2.aff4.model.rdf.FileImage
 import com.github.nava2.aff4.model.rdf.ImageStream
 import com.github.nava2.aff4.model.rdf.MapStream
-import com.github.nava2.aff4.model.rdf.TurtleIri
+import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import com.github.nava2.aff4.model.rdf.ZipSegment
 import com.github.nava2.guice.KAbstractModule
 import com.github.nava2.guice.key
@@ -47,10 +47,10 @@ internal class Aff4LogicalStandardToolDialectTest {
 
     assertThat(
       listOf(
-        MapStream::class to TurtleIri("aff4:Map"),
-        ImageStream::class to TurtleIri("aff4:ImageStream"),
-        ZipSegment::class to TurtleIri("aff4:ZipSegment"),
-        FileImage::class to TurtleIri("aff4:FileImage"),
+        MapStream::class to "aff4:Map".toTurtleIri(),
+        ImageStream::class to "aff4:ImageStream".toTurtleIri(),
+        ZipSegment::class to "aff4:ZipSegment".toTurtleIri(),
+        FileImage::class to "aff4:FileImage".toTurtleIri(),
       )
     ).allSatisfy { (klass, iri) ->
       assertThat(typeResolver[klass]).isEqualTo(iri)

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/RealAff4Model.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/RealAff4Model.kt
@@ -1,6 +1,7 @@
 package com.github.nava2.aff4.model
 
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
+import com.github.nava2.aff4.model.rdf.TurtleIri
 import com.github.nava2.aff4.model.rdf.annotations.RdfModel
 import com.github.nava2.aff4.model.rdf.annotations.allRdfTypes
 import com.github.nava2.aff4.model.rdf.evaluateSequence
@@ -34,7 +35,7 @@ internal class RealAff4Model @AssistedInject constructor(
   @Volatile
   private var closed = false
 
-  private val modelArns = mutableMapOf<KClass<*>, Set<String>>()
+  private val modelArns = mutableMapOf<KClass<*>, Collection<TurtleIri>>()
 
   override fun <T : Aff4RdfModel> query(modelType: KClass<T>): Sequence<T> {
     val modelRdfTypes = getModelRdfTypes(modelType)
@@ -50,7 +51,7 @@ internal class RealAff4Model @AssistedInject constructor(
   }
 
   private fun <T : Aff4RdfModel> queryPaginatedSubjects(
-    modelRdfType: String,
+    modelRdfType: TurtleIri,
     bindings: MutableMap<String, Resource>,
     modelType: KClass<T>
   ): Sequence<T> {
@@ -222,8 +223,10 @@ internal class RealAff4Model @AssistedInject constructor(
     return rdfExecutor.withReadOnlySession { block(it) }
   }
 
-  private fun getModelRdfTypes(modelType: KClass<*>): Set<String> {
-    return modelArns.getOrPut(modelType) { modelType.findAnnotation<RdfModel>()!!.allRdfTypes }
+  private fun getModelRdfTypes(modelType: KClass<*>): Collection<TurtleIri> {
+    return modelArns.getOrPut(modelType) {
+      modelType.findAnnotation<RdfModel>()!!.allRdfTypes
+    }
   }
 
   internal interface AssistedFactory {

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/RealAff4StreamOpener.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/RealAff4StreamOpener.kt
@@ -7,6 +7,7 @@ import com.github.nava2.aff4.io.SourceProvider
 import com.github.nava2.aff4.io.bounded
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
+import com.github.nava2.aff4.model.rdf.TurtleIri
 import com.github.nava2.aff4.model.rdf.annotations.RdfModel
 import com.github.nava2.aff4.model.rdf.annotations.allRdfTypes
 import com.github.nava2.aff4.model.rdf.createAff4Iri
@@ -158,7 +159,7 @@ internal class RealAff4StreamOpener @Inject constructor(
     statements: List<Statement>
   ): Aff4StreamSourceProvider {
     val rdfTypes = statements.asSequence()
-      .filter { it.predicate == connection.namespaces.iriFromTurtle("rdf:type") }
+      .filter { it.predicate == connection.namespaces.iriFromTurtle(TurtleIri.RDF_TYPE) }
       .mapNotNull { it.`object` as? Aff4Arn }
       .toSet()
 

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/ConnectionQueries.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/ConnectionQueries.kt
@@ -1,10 +1,11 @@
 package com.github.nava2.aff4.rdf
 
+import com.github.nava2.aff4.model.rdf.TurtleIri
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.Resource
 
 fun RdfConnection.querySubjectsByType(type: IRI): List<Resource> {
-  val query = queryStatements(pred = namespaces.iriFromTurtle("rdf:type"), obj = type).apply {
+  val query = queryStatements(pred = namespaces.iriFromTurtle(TurtleIri.RDF_TYPE), obj = type).apply {
     enableDuplicateFilter()
   }
   return query.use { result -> result.map { it.subject } }

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/NamespacesProvider.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/NamespacesProvider.kt
@@ -1,5 +1,6 @@
 package com.github.nava2.aff4.rdf
 
+import com.github.nava2.aff4.model.rdf.TurtleIri
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.ValueFactory
 
@@ -16,8 +17,8 @@ class NamespacesProvider internal constructor(
     return tryFindPrefix(prefix) ?: throw IllegalArgumentException("Prefix not found: $prefix")
   }
 
-  fun iriFromTurtle(turtleIri: String): IRI {
-    val (prefix, localName) = turtleIri.split(':')
+  fun iriFromTurtle(iri: TurtleIri): IRI {
+    val (prefix, localName) = iri
     val namespace = fromPrefix(prefix)
     return valueFactory.createIRI(namespace, localName)
   }

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/TurtleReaderAndInserter.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/TurtleReaderAndInserter.kt
@@ -32,7 +32,7 @@ internal class TurtleReaderAndInserter @AssistedInject constructor(
     aff4ModelClasses.asSequence()
       .filter { StoredRdfModel::class.isSuperclassOf(it) }
       .flatMap { it.findAnnotation<RdfModel>()!!.allRdfTypes }
-      .map { valueFactory.createAff4Iri(it.substringAfter(':')) }
+      .map { valueFactory.createAff4Iri(it.localName) }
       .toSet()
   }
 

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/RdfAnnotationTypeInfo.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/RdfAnnotationTypeInfo.kt
@@ -1,6 +1,7 @@
 package com.github.nava2.aff4.rdf.io
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import com.github.nava2.aff4.model.rdf.annotations.RdfModel
 import com.github.nava2.aff4.model.rdf.annotations.RdfSubject
 import com.github.nava2.aff4.model.rdf.annotations.RdfValue
@@ -72,10 +73,10 @@ internal data class RdfAnnotationTypeInfo<T : Any>(
           continue
         }
 
-        val predicate = namespacesProvider.iriFromTurtle(
+        val predicateIriString =
           findAnnotation<RdfValue>(memoizedPropertyMaps, type, parameter)?.turtleRdfIri
             ?: "aff4:${parameter.name}"
-        )
+        val predicate = namespacesProvider.iriFromTurtle(predicateIriString.toTurtleIri())
 
         otherParams.put(predicate, propertyInfo)
       }
@@ -83,7 +84,7 @@ internal data class RdfAnnotationTypeInfo<T : Any>(
       val rdfType = (type.findAnnotation<RdfModel>() ?: constructor.findAnnotation())!!.rdfType
       return RdfAnnotationTypeInfo(
         klass = type,
-        rdfType = namespacesProvider.iriFromTurtle(rdfType),
+        rdfType = namespacesProvider.iriFromTurtle(rdfType.toTurtleIri()),
         subjectProperties = subjectParams,
         otherProperties = otherParams.build(),
       )


### PR DESCRIPTION
… previously

This adds typesafety to how we interact with `String` `IRI` values before we have access to a `ValueFactory` to pass them into `RDF4J`.

This adds a new factory method for creating `TurtleIri` for `String.toTurtleIri()`

Extracted from #42