### PR TITLE
[Dialects] Use Tool Dialect in serializing images

### DIFF
--- a/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
+++ b/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
@@ -11,25 +11,24 @@ import com.github.nava2.guice.KAbstractModule
 import com.github.nava2.guice.key
 import com.github.nava2.guice.to
 import com.github.nava2.test.GuiceModule
+import com.google.inject.util.Modules
 import org.assertj.core.api.Assertions.assertThat
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 import javax.inject.Provider
 
 internal class Aff4LogicalStandardToolDialectTest {
   @GuiceModule
-  val module = object : KAbstractModule() {
-    override fun configure() {
-      install(Aff4TestModule)
-      bind<ValueFactory>().toInstance(SimpleValueFactory.getInstance())
-
-      install(Aff4LogicalStandardToolDialect.Module)
-      bind(key<ToolDialect>(DefaultToolDialect::class))
-        .to<Aff4LogicalStandardToolDialect>()
-    }
-  }
+  val module = Modules.combine(
+    Aff4TestModule,
+    Aff4LogicalStandardToolDialect.Module,
+    object : KAbstractModule() {
+      override fun configure() {
+        bind(key<ToolDialect>(DefaultToolDialect::class))
+          .to<Aff4LogicalStandardToolDialect>()
+      }
+    },
+  )
 
   @Inject
   private lateinit var aff4LogicalStandardToolDialect: Aff4LogicalStandardToolDialect

--- a/aff4/aff4-core/aff4-core-test/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-test/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 
   api(project(":aff4:aff4-core:aff4-core-guice"))
   api(project(":aff4:aff4-core:aff4-core-model"))
+  api(project(":aff4:aff4-core:aff4-core-model:aff4-core-model-api"))
   api(project(":aff4:aff4-core:aff4-core-okio"))
 
   api(Dependencies.ASSERTJ_CORE)

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestActionScopeModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestActionScopeModule.kt
@@ -1,0 +1,33 @@
+package com.github.nava2.aff4
+
+import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.action_scoped.ActionScope
+import com.github.nava2.guice.action_scoped.ActionScopeModule
+import com.github.nava2.test.GuiceExtension
+import javax.inject.Inject
+
+object TestActionScopeModule : KAbstractModule() {
+  override fun configure() {
+    install(ActionScopeModule)
+
+    bindSet<GuiceExtension.TestLifecycleAction> {
+      to<ActionScopeLifecycleAction>()
+    }
+  }
+
+  private class ActionScopeLifecycleAction @Inject constructor(
+    private val actionScope: ActionScope,
+  ) : GuiceExtension.TestLifecycleAction {
+    lateinit var action: ActionScope.Action
+
+    override fun beforeEach() {
+      if (::action.isInitialized) return
+      action = actionScope.start(mapOf())
+    }
+
+    override fun afterEach() {
+      if (!::action.isInitialized) return
+      action.close()
+    }
+  }
+}

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestToolDialectModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestToolDialectModule.kt
@@ -1,0 +1,35 @@
+package com.github.nava2.aff4
+
+import com.github.nava2.aff4.model.dialect.Aff4LogicalStandardToolDialect
+import com.github.nava2.aff4.model.dialect.DefaultToolDialect
+import com.github.nava2.aff4.model.dialect.DialectsModule
+import com.github.nava2.aff4.model.dialect.ToolDialect
+import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
+import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.action_scoped.ActionScoped
+import com.github.nava2.guice.key
+import com.github.nava2.guice.to
+import com.google.inject.Module
+import com.google.inject.binder.LinkedBindingBuilder
+import com.google.inject.binder.ScopedBindingBuilder
+import com.google.inject.util.Modules
+
+class TestToolDialectModule(
+  customBindingProvider: LinkedBindingBuilder<ToolDialect>.() -> ScopedBindingBuilder = {
+    to<Aff4LogicalStandardToolDialect>()
+  },
+) : Module by Modules.override(DialectsModule).with(
+  object : KAbstractModule() {
+    override fun configure() {
+      install(Aff4RdfModelPlugin)
+      install(Aff4LogicalStandardToolDialect.Module)
+
+      bind(key<ToolDialect>(DefaultToolDialect::class))
+        .customBindingProvider()
+
+      bind<ToolDialect>()
+        .customBindingProvider()
+        .`in`(ActionScoped::class.java)
+    }
+  },
+)

--- a/aff4/aff4-core/build.gradle.kts
+++ b/aff4/aff4-core/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
   implementation(project(":aff4:aff4-rdf"))
 
   testImplementation(Dependencies.JUNIT_JUPITER_PARAMS)
-  testImplementation(Dependencies.RDF4J_MODEL)
 
   testImplementation(project(":aff4:aff4-rdf:aff4-rdf-memory"))
   testImplementation(project(":aff4:aff4-compression:aff4-compression-snappy"))

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4CoreModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4CoreModule.kt
@@ -1,10 +1,11 @@
 package com.github.nava2.aff4
 
+import com.github.nava2.aff4.model.dialect.Aff4ToolDialectModule
 import com.github.nava2.aff4.model.dialect.DialectsModule
-import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
 import com.github.nava2.aff4.rdf.RdfRepositoryModule
 import com.github.nava2.aff4.rdf.io.RdfModelParserModule
 import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.action_scoped.ActionScopeModule
 
 object Aff4CoreModule : KAbstractModule() {
   override fun configure() {
@@ -12,11 +13,8 @@ object Aff4CoreModule : KAbstractModule() {
 
     install(RdfRepositoryModule)
     install(RdfModelParserModule)
-    install(Aff4RdfModelPlugin)
+    install(Aff4ToolDialectModule)
+    install(ActionScopeModule)
     install(DialectsModule)
   }
-
-  override fun equals(other: Any?): Boolean = this === other
-
-  override fun hashCode(): Int = javaClass.hashCode()
 }

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/Aff4ContainerBuilder.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/Aff4ContainerBuilder.kt
@@ -2,6 +2,7 @@ package com.github.nava2.aff4.container
 
 import com.github.nava2.aff4.io.SeekableSink
 import com.github.nava2.aff4.io.SizedSink
+import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.HashType
 import com.github.nava2.aff4.model.rdf.ImageStream
@@ -36,6 +37,7 @@ interface Aff4ContainerBuilder : Closeable {
   data class Context(
     val temporaryFileSystem: FileSystem,
     val arn: Aff4Arn,
+    val toolDialect: ToolDialect,
     val defaultTimeout: Timeout = Timeout.NONE,
   )
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/RealAff4ContainerBuilder.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/RealAff4ContainerBuilder.kt
@@ -28,10 +28,11 @@ internal class RealAff4ContainerBuilder @AssistedInject internal constructor(
   private val streamSinkFactory: Aff4StreamSinkFactory,
   private val rdfExecutor: RdfExecutor,
   private val containerMetaWriter: ContainerMetaWriter,
-  private val rdfModelSerializer: RdfModelSerializer,
+  rdfModelSerializerFactory: RdfModelSerializer.Factory,
   @Assisted context: Aff4ContainerBuilder.Context,
 ) : Aff4ContainerBuilder {
 
+  private val rdfModelSerializer = rdfModelSerializerFactory.create(context.toolDialect)
   private val temporaryFileSystem: FileSystem = context.temporaryFileSystem
   override val containerArn: Aff4Arn = context.arn
   override val defaultTimeout: Timeout = context.defaultTimeout

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ContainerLoaderTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ContainerLoaderTest.kt
@@ -10,9 +10,7 @@ import com.github.nava2.aff4.container.RealAff4ImageOpener.LoadedContainersConte
 import com.github.nava2.aff4.model.Aff4Container
 import com.github.nava2.aff4.model.rdf.createArn
 import com.github.nava2.aff4.satisfies
-import com.github.nava2.guice.KAbstractModule
 import com.github.nava2.test.GuiceModule
-import com.google.inject.util.Modules
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
@@ -22,7 +20,6 @@ import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -46,14 +43,7 @@ internal class ContainerLoaderTest {
   }
 
   @GuiceModule
-  val module = Modules.combine(
-    Aff4TestModule,
-    object : KAbstractModule() {
-      override fun configure() {
-        bind<ValueFactory>().toInstance(SimpleValueFactory.getInstance())
-      }
-    }
-  )
+  val module = Aff4TestModule
 
   @Inject
   private lateinit var containerLoader: ContainerLoader

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ToolDialectResolverTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ToolDialectResolverTest.kt
@@ -10,26 +10,17 @@ import com.github.nava2.guice.key
 import com.github.nava2.test.GuiceModule
 import com.google.inject.util.Modules
 import org.assertj.core.api.Assertions.assertThat
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 internal class ToolDialectResolverTest {
   @GuiceModule
   val module = Modules.combine(
-    Modules.override(Aff4TestModule)
-      .with(
-        object : KAbstractModule() {
-          override fun configure() {
-            bind(key<ToolDialect>(DefaultToolDialect::class))
-              .toInstance(DefaultToolDialectImpl)
-          }
-        },
-      ),
+    Aff4TestModule,
     object : KAbstractModule() {
       override fun configure() {
-        bind<ValueFactory>().toInstance(SimpleValueFactory.getInstance())
+        bind(key<ToolDialect>(DefaultToolDialect::class))
+          .toInstance(DefaultToolDialectImpl)
 
         bindSet<ToolDialect> {
           toInstance(ToolDialectOne)

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/TestAff4ContainerBuilderModule.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/TestAff4ContainerBuilderModule.kt
@@ -1,17 +1,22 @@
 package com.github.nava2.aff4.streams
 
 import com.github.nava2.aff4.Aff4CoreModule
+import com.github.nava2.aff4.TestActionScopeModule
 import com.github.nava2.aff4.TestRandomsModule
 import com.github.nava2.aff4.container.Aff4ContainerBuilderModule
 import com.github.nava2.aff4.container.Aff4ImageOpenerModule
+import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
 import com.github.nava2.guice.KAbstractModule
 
 object TestAff4ContainerBuilderModule : KAbstractModule() {
   override fun configure() {
-    install(Aff4ContainerBuilderModule)
     install(TestRandomsModule)
+    install(TestActionScopeModule)
+
+    install(Aff4ContainerBuilderModule)
     install(Aff4CoreModule)
 
     install(Aff4ImageOpenerModule)
+    install(Aff4RdfModelPlugin)
   }
 }

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4BevySinkTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4BevySinkTest.kt
@@ -1,6 +1,6 @@
 package com.github.nava2.aff4.streams.image_stream
 
-import com.github.nava2.aff4.Aff4CoreModule
+import com.github.nava2.aff4.TestActionScopeModule
 import com.github.nava2.aff4.UsingTemporary
 import com.github.nava2.aff4.io.content
 import com.github.nava2.aff4.io.md5
@@ -12,8 +12,10 @@ import com.github.nava2.aff4.model.rdf.None
 import com.github.nava2.aff4.model.rdf.hash
 import com.github.nava2.aff4.model.rdf.toAff4Path
 import com.github.nava2.aff4.rdf.MemoryRdfRepositoryPlugin
+import com.github.nava2.aff4.streams.TestAff4ContainerBuilderModule
 import com.github.nava2.aff4.streams.compression.SnappyCompression
 import com.github.nava2.test.GuiceModule
+import com.google.inject.util.Modules
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
@@ -26,11 +28,11 @@ import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 class Aff4BevySinkTest {
-
   @GuiceModule
-  val modules = listOf(
-    Aff4CoreModule,
+  val module = Modules.combine(
+    TestAff4ContainerBuilderModule,
     MemoryRdfRepositoryPlugin,
+    TestActionScopeModule,
   )
 
   @Inject

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4ImageStreamSinkTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/image_stream/Aff4ImageStreamSinkTest.kt
@@ -7,6 +7,8 @@ import com.github.nava2.aff4.container.RealAff4ContainerBuilder
 import com.github.nava2.aff4.io.decode
 import com.github.nava2.aff4.io.repeatByteString
 import com.github.nava2.aff4.model.Aff4ImageOpener
+import com.github.nava2.aff4.model.dialect.DefaultToolDialect
+import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.CompressionMethod
 import com.github.nava2.aff4.model.rdf.Hash
@@ -19,6 +21,7 @@ import com.github.nava2.aff4.streams.TestAff4ContainerBuilderModule
 import com.github.nava2.aff4.streams.compression.Aff4SnappyPlugin
 import com.github.nava2.aff4.streams.compression.SnappyCompression
 import com.github.nava2.test.GuiceModule
+import com.google.inject.util.Modules
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
@@ -35,7 +38,7 @@ import javax.inject.Inject
 class Aff4ImageStreamSinkTest {
 
   @GuiceModule
-  val modules = listOf(
+  val module = Modules.combine(
     TestAff4ContainerBuilderModule,
     Aff4BaseStreamModule,
     MemoryRdfRepositoryPlugin,
@@ -53,6 +56,10 @@ class Aff4ImageStreamSinkTest {
 
   @Inject
   private lateinit var aff4ContainerBuilderFactory: Aff4ContainerBuilder.Factory
+
+  @Inject
+  @field:DefaultToolDialect
+  private lateinit var toolDialect: ToolDialect
 
   @UsingTemporary
   private lateinit var outputFileSystem: FileSystem
@@ -72,6 +79,7 @@ class Aff4ImageStreamSinkTest {
       Aff4ContainerBuilder.Context(
         temporaryFileSystem = imageFileSystem,
         arn = containerArn,
+        toolDialect = toolDialect,
       ),
     ) as RealAff4ContainerBuilder
   }

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/Aff4MapStreamSinkTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/Aff4MapStreamSinkTest.kt
@@ -1,6 +1,7 @@
 package com.github.nava2.aff4.streams.map_stream
 
 import com.github.nava2.aff4.Aff4BaseStreamModule
+import com.github.nava2.aff4.TestActionScopeModule
 import com.github.nava2.aff4.UsingTemporary
 import com.github.nava2.aff4.container.Aff4ContainerBuilder
 import com.github.nava2.aff4.container.RealAff4ContainerBuilder
@@ -11,6 +12,8 @@ import com.github.nava2.aff4.io.md5
 import com.github.nava2.aff4.io.relativeTo
 import com.github.nava2.aff4.io.repeatByteString
 import com.github.nava2.aff4.model.Aff4ImageOpener
+import com.github.nava2.aff4.model.dialect.DefaultToolDialect
+import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.model.rdf.CompressionMethod
 import com.github.nava2.aff4.model.rdf.HashType
@@ -25,6 +28,7 @@ import com.github.nava2.aff4.streams.compression.SnappyCompression
 import com.github.nava2.aff4.streams.image_stream.Bevy
 import com.github.nava2.aff4.streams.symbolics.Symbolics
 import com.github.nava2.test.GuiceModule
+import com.google.inject.util.Modules
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.decodeHex
@@ -41,11 +45,12 @@ import javax.inject.Inject
 class Aff4MapStreamSinkTest {
 
   @GuiceModule
-  val modules = listOf(
+  val module = Modules.combine(
     TestAff4ContainerBuilderModule,
     Aff4BaseStreamModule,
     MemoryRdfRepositoryPlugin,
     Aff4SnappyPlugin,
+    TestActionScopeModule,
   )
 
   @Inject
@@ -65,6 +70,10 @@ class Aff4MapStreamSinkTest {
 
   @Inject
   private lateinit var snappyCompression: SnappyCompression
+
+  @Inject
+  @field:DefaultToolDialect
+  private lateinit var toolDialect: ToolDialect
 
   private val imageFileSystem by lazy { sha256FileSystemFactory.create(tempFileSystem, "sha256".toPath()) }
 
@@ -88,6 +97,7 @@ class Aff4MapStreamSinkTest {
       Aff4ContainerBuilder.Context(
         temporaryFileSystem = imageFileSystem,
         arn = containerArn,
+        toolDialect = toolDialect,
       ),
     ) as RealAff4ContainerBuilder
   }

--- a/aff4/aff4-rdf/aff4-rdf-memory/build.gradle.kts
+++ b/aff4/aff4-rdf/aff4-rdf-memory/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
   implementation(project(":aff4:aff4-core:aff4-core-guice"))
   implementation(project(":aff4:aff4-rdf:aff4-rdf-api"))
+  implementation(project(":aff4:aff4-rdf"))
 }

--- a/aff4/aff4-rdf/aff4-rdf-memory/src/main/kotlin/com/github/nava2/aff4/rdf/MemoryRdfRepositoryPlugin.kt
+++ b/aff4/aff4-rdf/aff4-rdf-memory/src/main/kotlin/com/github/nava2/aff4/rdf/MemoryRdfRepositoryPlugin.kt
@@ -5,6 +5,8 @@ import com.github.nava2.guice.to
 
 object MemoryRdfRepositoryPlugin : KAff4Plugin(pluginIdentifier = "kaff4:aff4-rdf-memory") {
   override fun configurePlugin() {
+    install(RdfRepositoryModule)
+
     bindRdfRepositoryConfiguration().to<MemoryRdfRepositoryConfiguration>()
   }
 }

--- a/aff4/aff4-rdf/build.gradle.kts
+++ b/aff4/aff4-rdf/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
   implementation(kotlin("reflect"))
 
   api(project(":aff4:aff4-core:aff4-core-guice"))
+  api(project(":aff4:aff4-core:aff4-core-model:aff4-core-model-api"))
   api(project(":aff4:aff4-rdf:aff4-rdf-api"))
 
   api(Dependencies.GUICE)
@@ -21,7 +22,6 @@ dependencies {
   implementation(Dependencies.RDF4J_SAIL_API)
 
   implementation(project(":aff4:aff4-core:aff4-core-kotlin"))
-  implementation(project(":aff4:aff4-core:aff4-core-model:aff4-core-model-api"))
 
   testImplementation(project(":aff4:aff4-core"))
   testImplementation(project(":aff4:aff4-core:aff4-core-model"))

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/RdfModelParserModule.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/RdfModelParserModule.kt
@@ -1,15 +1,27 @@
 package com.github.nava2.aff4.rdf.io
 
+import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.rdf.io.literals.RdfLiteralConvertersModule
 import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.action_scoped.ActionScoped
+import com.github.nava2.guice.assistedFactoryModule
 import com.github.nava2.guice.to
+import com.google.inject.Provides
 
 object RdfModelParserModule : KAbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 
     install(RdfLiteralConvertersModule)
+    install(assistedFactoryModule<RdfModelSerializer.Factory>())
 
     bind<RdfModelParser>().to<RealRdfModelParser>()
   }
+
+  @Provides
+  @ActionScoped
+  internal fun providesRdfAnnotationTypeInfoLookup(
+    rdfAnnotationTypeInfo: RdfAnnotationTypeInfo.Lookup.Factory,
+    @ActionScoped toolDialect: ToolDialect,
+  ): RdfAnnotationTypeInfo.Lookup = rdfAnnotationTypeInfo.withDialect(toolDialect)
 }

--- a/aff4/aff4-rdf/src/test/kotlin/com/github/nava2/aff4/rdf/RealRdfExecutorTest.kt
+++ b/aff4/aff4-rdf/src/test/kotlin/com/github/nava2/aff4/rdf/RealRdfExecutorTest.kt
@@ -1,8 +1,11 @@
 package com.github.nava2.aff4.rdf
 
 import com.github.nava2.aff4.Aff4CoreModule
+import com.github.nava2.aff4.TestActionScopeModule
+import com.github.nava2.aff4.container.Aff4ImageOpenerModule
 import com.github.nava2.aff4.isIllegalStateException
 import com.github.nava2.test.GuiceModule
+import com.google.inject.util.Modules
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
@@ -14,7 +17,12 @@ import javax.inject.Inject
 
 internal class RealRdfExecutorTest {
   @GuiceModule
-  val modules = listOf(Aff4CoreModule, MemoryRdfRepositoryPlugin)
+  val module = Modules.combine(
+    Aff4CoreModule,
+    MemoryRdfRepositoryPlugin,
+    Aff4ImageOpenerModule,
+    TestActionScopeModule,
+  )
 
   @Inject
   lateinit var realRdfExecutor: RealRdfExecutor


### PR DESCRIPTION
This forces us to specify the `ToolDialect` when we start creating new images. This must be done to make sure we write the image with the expected specifications.

Extracted from #42