### PR TITLE
[Dialects] Adjust `DialectTypeResolver.Builder.empty()` -> `newBuilde…

### DIFF
--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolver.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolver.kt
@@ -28,7 +28,7 @@ interface DialectTypeResolver {
   }
 
   object Builder {
-    fun empty(): SimpleBuilder = SimpleBuilder()
+    fun newBuilder(): SimpleBuilder = SimpleBuilder()
 
     fun withExisting(typeResolver: DialectTypeResolver): SimpleBuilder = SimpleBuilder(typeResolver)
 
@@ -38,7 +38,7 @@ interface DialectTypeResolver {
     ): AnnotationBasedBuilder<A> = AnnotationBasedBuilder(annotationKlass, extractor)
   }
 
-  open class BuilderBase<SELF : BuilderBase<SELF>> internal constructor() {
+  open class BuilderBase<out SELF : BuilderBase<SELF>> internal constructor() {
     private val primaryMappings = mutableMapOf<KClass<*>, TurtleIri>()
     private val mappings = ArrayListMultimap.create<KClass<*>, TurtleIri>()
 
@@ -129,5 +129,9 @@ interface DialectTypeResolver {
     inline fun <reified T : Aff4RdfModel> register(): AnnotationBasedBuilder<A> {
       return register(T::class)
     }
+  }
+
+  companion object {
+    val EMPTY = Builder.newBuilder().build()
   }
 }

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/test/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolverTest.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/test/kotlin/com/github/nava2/aff4/model/dialect/DialectTypeResolverTest.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
 internal class DialectTypeResolverTest {
   @Test
   fun `SimpleBuilder - Empty never resolves`() {
-    val typeResolver = DialectTypeResolver.Builder.empty().build()
+    val typeResolver = DialectTypeResolver.EMPTY
 
     assertThat(typeResolver[SimpleModel::class]).isNull()
     assertThat(typeResolver[SIMPLE_IRI]).isNull()
@@ -18,7 +18,7 @@ internal class DialectTypeResolverTest {
 
   @Test
   fun `SimpleBuilder - registered types resolve`() {
-    val typeResolver = DialectTypeResolver.Builder.empty()
+    val typeResolver = DialectTypeResolver.Builder.newBuilder()
       .register(SimpleModel::class, SIMPLE_IRI)
       .build()
 
@@ -31,7 +31,7 @@ internal class DialectTypeResolverTest {
 
   @Test
   fun `SimpleBuilder - allows duplicate IRIs, returns primary for KClass key`() {
-    val typeResolver = DialectTypeResolver.Builder.empty()
+    val typeResolver = DialectTypeResolver.Builder.newBuilder()
       .register(SimpleModel::class, SIMPLE_IRI, SIMPLE_2_IRI)
       .build()
 

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModelPlugin.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/rdf/Aff4RdfModelPlugin.kt
@@ -1,7 +1,6 @@
 package com.github.nava2.aff4.model.rdf
 
 import com.github.nava2.aff4.plugins.KAff4Plugin
-import com.github.nava2.guice.to
 
 object Aff4RdfModelPlugin : KAff4Plugin(pluginIdentifier = "kaff4:aff4-rdf-models") {
   override fun configurePlugin() {

--- a/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
+++ b/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
@@ -1,6 +1,7 @@
 package com.github.nava2.aff4.model.dialect
 
 import com.github.nava2.aff4.Aff4TestModule
+import com.github.nava2.aff4.TestActionScopeModule
 import com.github.nava2.aff4.model.Aff4Container
 import com.github.nava2.aff4.model.rdf.FileImage
 import com.github.nava2.aff4.model.rdf.ImageStream
@@ -8,6 +9,7 @@ import com.github.nava2.aff4.model.rdf.MapStream
 import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import com.github.nava2.aff4.model.rdf.ZipSegment
 import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.action_scoped.ActionScoped
 import com.github.nava2.guice.key
 import com.github.nava2.guice.to
 import com.github.nava2.test.GuiceModule
@@ -21,11 +23,16 @@ internal class Aff4LogicalStandardToolDialectTest {
   @GuiceModule
   val module = Modules.combine(
     Aff4TestModule,
+    TestActionScopeModule,
     Aff4LogicalStandardToolDialect.Module,
     object : KAbstractModule() {
       override fun configure() {
         bind(key<ToolDialect>(DefaultToolDialect::class))
           .to<Aff4LogicalStandardToolDialect>()
+
+        bind<ToolDialect>()
+          .to<Aff4LogicalStandardToolDialect>()
+          .`in`(ActionScoped::class.java)
       }
     },
   )

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/AssertJAssertionsExtensions.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/AssertJAssertionsExtensions.kt
@@ -3,5 +3,10 @@ package com.github.nava2.aff4
 import org.assertj.core.api.AbstractAssert
 import java.util.function.Consumer
 
-inline fun <SELF, ACTUAL> AbstractAssert<SELF, ACTUAL>.satisfies(crossinline consumer: (ACTUAL) -> Unit): SELF
-  where SELF : AbstractAssert<SELF, ACTUAL> = satisfies(Consumer { consumer(it) })
+inline fun <SELF, ACTUAL> SELF.satisfies(crossinline consumer: (ACTUAL) -> Unit): SELF
+  where SELF : AbstractAssert<out SELF, ACTUAL> = satisfies(Consumer { consumer(it) })
+
+inline fun <reified T : Any> AbstractAssert<*, *>.isInstanceOf(): AbstractAssert<*, T> {
+  @Suppress("UNCHECKED_CAST")
+  return isInstanceOf(T::class.java) as AbstractAssert<*, T>
+}

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestToolDialectModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestToolDialectModule.kt
@@ -14,8 +14,8 @@ import com.google.inject.binder.LinkedBindingBuilder
 import com.google.inject.binder.ScopedBindingBuilder
 import com.google.inject.util.Modules
 
-class TestToolDialectModule(
-  customBindingProvider: LinkedBindingBuilder<ToolDialect>.() -> ScopedBindingBuilder = {
+data class TestToolDialectModule(
+  val customBindingProvider: LinkedBindingBuilder<ToolDialect>.() -> ScopedBindingBuilder = {
     to<Aff4LogicalStandardToolDialect>()
   },
 ) : Module by Modules.override(DialectsModule).with(

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ToolDialectResolverTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ToolDialectResolverTest.kt
@@ -1,27 +1,31 @@
 package com.github.nava2.aff4.container
 
 import com.github.nava2.aff4.Aff4TestModule
+import com.github.nava2.aff4.TestActionScopeModule
+import com.github.nava2.aff4.TestToolDialectModule
+import com.github.nava2.aff4.isInstanceOf
 import com.github.nava2.aff4.model.Aff4Container
-import com.github.nava2.aff4.model.dialect.DefaultToolDialect
 import com.github.nava2.aff4.model.dialect.DialectTypeResolver
 import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.guice.KAbstractModule
-import com.github.nava2.guice.key
+import com.github.nava2.guice.to
 import com.github.nava2.test.GuiceModule
 import com.google.inject.util.Modules
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
+import javax.inject.Singleton
 
 internal class ToolDialectResolverTest {
   @GuiceModule
   val module = Modules.combine(
     Aff4TestModule,
+    TestActionScopeModule,
+    TestToolDialectModule {
+      to<DefaultToolDialectImpl>()
+    },
     object : KAbstractModule() {
       override fun configure() {
-        bind(key<ToolDialect>(DefaultToolDialect::class))
-          .toInstance(DefaultToolDialectImpl)
-
         bindSet<ToolDialect> {
           toInstance(ToolDialectOne)
           toInstance(ToolDialectTwo)
@@ -44,7 +48,7 @@ internal class ToolDialectResolverTest {
   @Test
   fun `resolver returns default dialect if none are found`() {
     assertThat(toolDialectResolver.forTool(Aff4Container.ToolMetadata("V", "T")))
-      .isEqualTo(DefaultToolDialectImpl)
+      .isInstanceOf<DefaultToolDialectImpl>()
   }
 }
 
@@ -54,8 +58,7 @@ private object ToolDialectOne : ToolDialect {
     tool = "One",
   )
 
-  override val typeResolver: DialectTypeResolver
-    get() = TODO("Not yet implemented")
+  override val typeResolver: DialectTypeResolver = DialectTypeResolver.EMPTY
 
   override fun isApplicable(toolMetadata: Aff4Container.ToolMetadata): Boolean {
     return toolMetadata == this.toolMetadata
@@ -68,17 +71,17 @@ private object ToolDialectTwo : ToolDialect {
     tool = "Two",
   )
 
-  override val typeResolver: DialectTypeResolver
-    get() = TODO("Not yet implemented")
+  override val typeResolver: DialectTypeResolver = DialectTypeResolver.EMPTY
 
   override fun isApplicable(toolMetadata: Aff4Container.ToolMetadata): Boolean {
     return toolMetadata == this.toolMetadata
   }
 }
 
-private object DefaultToolDialectImpl : ToolDialect {
-  override val typeResolver: DialectTypeResolver
-    get() = TODO("Not yet implemented")
+@Singleton
+private class DefaultToolDialectImpl @Inject constructor() : ToolDialect {
+
+  override val typeResolver: DialectTypeResolver = DialectTypeResolver.EMPTY
 
   override fun isApplicable(toolMetadata: Aff4Container.ToolMetadata): Boolean {
     error("This should not be called")

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamEntryTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamEntryTest.kt
@@ -188,8 +188,8 @@ class MapStreamEntryTest {
   }
 }
 
-private fun <SELF> AbstractObjectAssert<SELF, MapStreamEntry>.canNotMerge(other: MapStreamEntry): SELF
-  where SELF : AbstractObjectAssert<SELF, MapStreamEntry> {
+private fun <SELF> SELF.canNotMerge(other: MapStreamEntry): SELF
+  where SELF : AbstractObjectAssert<out SELF, MapStreamEntry> {
   return satisfies { entry: MapStreamEntry ->
     assertThat(entry.canMerge(other)).`as` { "!entry.canMerge(other) [entry=$entry, other=$other]" }.isFalse()
 

--- a/aff4/aff4-rdf/src/test/kotlin/com/github/nava2/aff4/rdf/io/RdfModelParserTest.kt
+++ b/aff4/aff4-rdf/src/test/kotlin/com/github/nava2/aff4/rdf/io/RdfModelParserTest.kt
@@ -189,7 +189,7 @@ internal class RdfModelParserTest {
 
 @Singleton
 private class CustomToolDialect @Inject constructor() : ToolDialect {
-  override val typeResolver: DialectTypeResolver = DialectTypeResolver.Builder.empty()
+  override val typeResolver: DialectTypeResolver = DialectTypeResolver.Builder.newBuilder()
     .register(ModelClassExtendWithSubject::class, "test://extend-with-subject")
     .register(PrimitiveModelWithInt::class, "test://primitive-model-class")
     .register(PrimitiveModelWithString::class, "test://primitive-model-with-string")


### PR DESCRIPTION
…r()`, add `EMPTY` constant

This does an incremental rename/refactor to make things more obvious when testing resolvers.

Extracted from #42