### PR TITLE
[IntervalTree] Remove `aff4` from `interval-tree` project

### DIFF
--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/IntervalTreeExtensions.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/IntervalTreeExtensions.kt
@@ -1,7 +1,7 @@
 package com.github.nava2.aff4.streams.map_stream
 
-import com.github.nava2.aff4.interval_tree.IntervalTree
 import com.github.nava2.aff4.yieldNotNull
+import com.github.nava2.interval_tree.IntervalTree
 import java.util.SortedSet
 
 private fun Sequence<MapStreamEntry>.compressed(requireSort: Boolean): Sequence<MapStreamEntry> = sequence {

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamEntry.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamEntry.kt
@@ -1,7 +1,7 @@
 package com.github.nava2.aff4.streams.map_stream
 
-import com.github.nava2.aff4.interval_tree.Interval
 import com.github.nava2.aff4.model.rdf.Aff4Arn
+import com.github.nava2.interval_tree.Interval
 import okio.BufferedSink
 
 data class MapStreamEntry(

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamMap.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamMap.kt
@@ -1,7 +1,7 @@
 package com.github.nava2.aff4.streams.map_stream
 
-import com.github.nava2.aff4.interval_tree.Interval
-import com.github.nava2.aff4.interval_tree.IntervalTree
+import com.github.nava2.interval_tree.Interval
+import com.github.nava2.interval_tree.IntervalTree
 import com.google.common.base.MoreObjects
 import org.eclipse.rdf4j.model.IRI
 import java.util.SortedSet

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamMapReader.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamMapReader.kt
@@ -1,9 +1,9 @@
 package com.github.nava2.aff4.streams.map_stream
 
 import com.github.nava2.aff4.container.ContainerDataFileSystemProvider
-import com.github.nava2.aff4.interval_tree.IntervalTree
 import com.github.nava2.aff4.model.rdf.MapStream
 import com.github.nava2.aff4.streams.symbolics.Symbolics
+import com.github.nava2.interval_tree.IntervalTree
 import okio.buffer
 import org.eclipse.rdf4j.model.IRI
 import javax.inject.Inject

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/SeekableMapDataStreamChunkSink.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/map_stream/SeekableMapDataStreamChunkSink.kt
@@ -1,9 +1,9 @@
 package com.github.nava2.aff4.streams.map_stream
 
-import com.github.nava2.aff4.interval_tree.IntervalTree
 import com.github.nava2.aff4.io.Seekable
 import com.github.nava2.aff4.model.rdf.Aff4Arn
 import com.github.nava2.aff4.streams.Aff4Sink
+import com.github.nava2.interval_tree.IntervalTree
 import okio.Buffer
 import okio.Timeout
 

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamEntryIntervalTreeExtensionsTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamEntryIntervalTreeExtensionsTest.kt
@@ -3,8 +3,8 @@ package com.github.nava2.aff4.streams.map_stream
 import com.github.nava2.aff4.Aff4CoreModule
 import com.github.nava2.aff4.TestActionScopeModule
 import com.github.nava2.aff4.container.Aff4ImageOpenerModule
-import com.github.nava2.aff4.interval_tree.IntervalTree
 import com.github.nava2.aff4.rdf.MemoryRdfRepositoryPlugin
+import com.github.nava2.interval_tree.IntervalTree
 import com.github.nava2.test.GuiceModule
 import com.google.inject.util.Modules
 import org.assertj.core.api.Assertions.assertThat

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamMapReaderTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/map_stream/MapStreamMapReaderTest.kt
@@ -3,9 +3,9 @@ package com.github.nava2.aff4.streams.map_stream
 import com.github.nava2.aff4.Aff4ImageTestModule
 import com.github.nava2.aff4.BaseLinear
 import com.github.nava2.aff4.UnderTest
-import com.github.nava2.aff4.interval_tree.Interval
 import com.github.nava2.aff4.model.Aff4Model
 import com.github.nava2.aff4.model.rdf.MapStream
+import com.github.nava2.interval_tree.Interval
 import com.github.nava2.test.GuiceModule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.ObjectAssert

--- a/interval-tree/src/main/kotlin/com/github/nava2/interval_tree/Interval.kt
+++ b/interval-tree/src/main/kotlin/com/github/nava2/interval_tree/Interval.kt
@@ -21,7 +21,7 @@
 // SOFTWARE.
 //
 // Original: https://github.com/charcuterie/interval-tree/blob/65dc2fc8f754127aa09fba0dff6f43b10ac151cb/src/datastructures/Interval.java
-package com.github.nava2.aff4.interval_tree
+package com.github.nava2.interval_tree
 
 /**
  * Closed-open, [), interval on the integer number line.

--- a/interval-tree/src/main/kotlin/com/github/nava2/interval_tree/IntervalTree.kt
+++ b/interval-tree/src/main/kotlin/com/github/nava2/interval_tree/IntervalTree.kt
@@ -31,7 +31,7 @@
   "ReturnCount",
 )
 
-package com.github.nava2.aff4.interval_tree
+package com.github.nava2.interval_tree
 
 import com.google.common.annotations.VisibleForTesting
 import java.util.Optional

--- a/interval-tree/src/test/kotlin/com/github/nava2/interval_tree/IntervalTreeTest.kt
+++ b/interval-tree/src/test/kotlin/com/github/nava2/interval_tree/IntervalTreeTest.kt
@@ -26,7 +26,7 @@
   "LargeClass",
 )
 
-package com.github.nava2.aff4.interval_tree
+package com.github.nava2.interval_tree
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy


### PR DESCRIPTION
This renames the package to remove the `aff4` marker as it is not `aff4` specific. 

This will be extracted to it's own project.