### PR TITLE
[Misk] Replace custom guice bindings with `misk-inject` instead

### DIFF
--- a/aff4/aff4-compression/aff4-compression-snappy/build.gradle.kts
+++ b/aff4/aff4-compression/aff4-compression-snappy/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   api(project(":aff4:aff4-core:aff4-core-model:aff4-core-model-api"))
 
   implementation(Dependencies.GUICE)
+  implementation(Dependencies.MISK_INJECT)
   implementation("org.xerial.snappy:snappy-java:1.1.8.4")
 
   implementation(project(":aff4:aff4-core:aff4-core-guice"))

--- a/aff4/aff4-core/aff4-core-guice/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-guice/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 
   api(Dependencies.GUICE)
   api(Dependencies.JAVAX_INJECT)
+  api(Dependencies.MISK_INJECT)
 
   implementation(Dependencies.GUICE_ASSISTED_INJECT)
 }

--- a/aff4/aff4-core/aff4-core-guice/src/main/kotlin/com/github/nava2/guice/KAff4AbstractModule.kt
+++ b/aff4/aff4-core/aff4-core-guice/src/main/kotlin/com/github/nava2/guice/KAff4AbstractModule.kt
@@ -1,30 +1,25 @@
 package com.github.nava2.guice
 
 import com.google.inject.AbstractModule
-import com.google.inject.binder.AnnotatedBindingBuilder
+import com.google.inject.Binder
 import com.google.inject.multibindings.MapBinder
 import com.google.inject.multibindings.Multibinder
+import misk.inject.KAbstractModule
 import kotlin.reflect.KClass
 
 /**
  * Provides many Kotlin abstractions to ease binding content within an [AbstractModule].
  */
-abstract class KAbstractModule protected constructor() : AbstractModule() {
+abstract class KAff4AbstractModule protected constructor() : KAbstractModule() {
   abstract override fun configure()
 
-  protected inline fun <reified T> bind(): AnnotatedBindingBuilder<T> {
-    return bind(T::class.java)
-  }
-
-  protected inline fun <reified T> requireBinding() {
-    return requireBinding(T::class.java)
-  }
+  override fun binder(): Binder = super.binder().skipSources(KAff4AbstractModule::class.java)
 
   protected inline fun <reified T> requireBinding(annotatedWith: KClass<out Annotation>) {
     return requireBinding(key<T>(annotatedWith))
   }
 
-  protected inline fun <reified T> bindSet(
+  protected inline fun <reified T : Any> bindSet(
     block: KSetMultibinderHelper<T>.() -> Unit
   ): Multibinder<T> {
     val multibinder = Multibinder.newSetBinder(binder(), typeLiteral<T>())
@@ -32,7 +27,7 @@ abstract class KAbstractModule protected constructor() : AbstractModule() {
     return multibinder
   }
 
-  protected inline fun <reified T> bindSet(
+  protected inline fun <reified T : Any> bindSet(
     annotatedWith: KClass<out Annotation>,
     block: KSetMultibinderHelper<T>.() -> Unit
   ): Multibinder<T> {

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   api(project(":aff4:aff4-core:aff4-core-guice"))
 
   implementation(Dependencies.GUICE)
+  implementation(Dependencies.MISK_INJECT)
 
   implementation(kotlin("reflect"))
 }

--- a/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/Aff4ToolDialectModule.kt
+++ b/aff4/aff4-core/aff4-core-model/aff4-core-model-api/src/main/kotlin/com/github/nava2/aff4/model/dialect/Aff4ToolDialectModule.kt
@@ -1,8 +1,8 @@
 package com.github.nava2.aff4.model.dialect
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 
-object Aff4ToolDialectModule : KAbstractModule() {
+object Aff4ToolDialectModule : KAff4AbstractModule() {
   override fun configure() {
     requireBinding<ToolDialect>(DefaultToolDialect::class)
 

--- a/aff4/aff4-core/aff4-core-model/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-model/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
   api(Dependencies.OKIO)
   api(Dependencies.RDF4J_MODEL_API)
 
+  implementation(Dependencies.MISK_INJECT)
+
   testImplementation(Dependencies.RDF4J_MODEL)
 
   testImplementation(project(":guice-action-scoped"))

--- a/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialect.kt
+++ b/aff4/aff4-core/aff4-core-model/src/main/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialect.kt
@@ -2,7 +2,7 @@ package com.github.nava2.aff4.model.dialect
 
 import com.github.nava2.aff4.model.Aff4Container
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.google.inject.Provides
 import javax.inject.Singleton
 import kotlin.annotation.AnnotationRetention.RUNTIME
@@ -22,7 +22,7 @@ class Aff4LogicalStandardToolDialect internal constructor(
   @Retention(RUNTIME)
   annotation class RdfStandardType(val rdfType: String)
 
-  object Module : KAbstractModule() {
+  object Module : KAff4AbstractModule() {
     override fun configure() {
       install(Aff4ToolDialectModule)
     }

--- a/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
+++ b/aff4/aff4-core/aff4-core-model/src/test/kotlin/com/github/nava2/aff4/model/dialect/Aff4LogicalStandardToolDialectTest.kt
@@ -8,7 +8,7 @@ import com.github.nava2.aff4.model.rdf.ImageStream
 import com.github.nava2.aff4.model.rdf.MapStream
 import com.github.nava2.aff4.model.rdf.TurtleIri.Companion.toTurtleIri
 import com.github.nava2.aff4.model.rdf.ZipSegment
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScoped
 import com.github.nava2.guice.key
 import com.github.nava2.guice.to
@@ -25,7 +25,7 @@ internal class Aff4LogicalStandardToolDialectTest {
     Aff4TestModule,
     TestActionScopeModule,
     Aff4LogicalStandardToolDialect.Module,
-    object : KAbstractModule() {
+    object : KAff4AbstractModule() {
       override fun configure() {
         bind(key<ToolDialect>(DefaultToolDialect::class))
           .to<Aff4LogicalStandardToolDialect>()

--- a/aff4/aff4-core/aff4-core-test/build.gradle.kts
+++ b/aff4/aff4-core/aff4-core-test/build.gradle.kts
@@ -7,11 +7,12 @@ dependencies {
   api(project(":aff4:aff4-core:aff4-core-okio"))
 
   api(Dependencies.ASSERTJ_CORE)
+  api(Dependencies.GUICE)
   api(Dependencies.JAVAX_INJECT)
   api(Dependencies.JUNIT_JUIPTER_API)
-  api(Dependencies.GUICE)
   api(Dependencies.OKIO)
 
+  implementation(Dependencies.MISK_INJECT)
   implementation(project(":guice-action-scoped"))
 
   implementation(project(":aff4:aff4-core"))

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/Aff4ImageTestModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/Aff4ImageTestModule.kt
@@ -3,7 +3,7 @@ package com.github.nava2.aff4
 import com.github.nava2.aff4.container.Aff4ImageOpenerModule
 import com.github.nava2.aff4.model.Aff4Image
 import com.github.nava2.aff4.model.Aff4ImageOpener
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.test.GuiceExtension
 import com.google.inject.Provides
 import okio.FileSystem
@@ -11,7 +11,7 @@ import okio.Path.Companion.toPath
 import javax.inject.Inject
 import javax.inject.Singleton
 
-abstract class Aff4ImageTestModule(val imageName: String) : KAbstractModule() {
+abstract class Aff4ImageTestModule(val imageName: String) : KAff4AbstractModule() {
   val imagePath = imageName.toPath()
 
   override fun configure() {

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/Aff4TestModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/Aff4TestModule.kt
@@ -3,13 +3,13 @@ package com.github.nava2.aff4
 import com.github.nava2.aff4.io.relativeTo
 import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
 import com.github.nava2.aff4.rdf.MemoryRdfRepositoryPlugin
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.google.inject.Provides
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import javax.inject.Singleton
 
-object Aff4TestModule : KAbstractModule() {
+object Aff4TestModule : KAff4AbstractModule() {
   override fun configure() {
     bind<FileSystem>()
       .annotatedWith(ForResources::class.java)

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestActionScopeModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestActionScopeModule.kt
@@ -1,12 +1,12 @@
 package com.github.nava2.aff4
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScope
 import com.github.nava2.guice.action_scoped.ActionScopeModule
 import com.github.nava2.test.GuiceExtension
 import javax.inject.Inject
 
-object TestActionScopeModule : KAbstractModule() {
+object TestActionScopeModule : KAff4AbstractModule() {
   override fun configure() {
     install(ActionScopeModule)
 

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestRandomsModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestRandomsModule.kt
@@ -1,6 +1,6 @@
 package com.github.nava2.aff4
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.google.inject.Module
 import com.google.inject.util.Modules
 import java.util.Random
@@ -8,7 +8,7 @@ import javax.inject.Provider
 
 object TestRandomsModule : Module by Modules.override(RandomsModule)
   .with(
-    object : KAbstractModule() {
+    object : KAff4AbstractModule() {
       override fun configure() {
         bind<Random>().toProvider(Provider { Random(0) })
       }

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestToolDialectModule.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/aff4/TestToolDialectModule.kt
@@ -5,7 +5,7 @@ import com.github.nava2.aff4.model.dialect.DefaultToolDialect
 import com.github.nava2.aff4.model.dialect.DialectsModule
 import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScoped
 import com.github.nava2.guice.key
 import com.github.nava2.guice.to
@@ -19,7 +19,7 @@ data class TestToolDialectModule(
     to<Aff4LogicalStandardToolDialect>()
   },
 ) : Module by Modules.override(DialectsModule).with(
-  object : KAbstractModule() {
+  object : KAff4AbstractModule() {
     override fun configure() {
       install(Aff4RdfModelPlugin)
       install(Aff4LogicalStandardToolDialect.Module)
@@ -27,7 +27,7 @@ data class TestToolDialectModule(
       bind(key<ToolDialect>(DefaultToolDialect::class))
         .customBindingProvider()
 
-      bind<ToolDialect>()
+      bind(ToolDialect::class.java)
         .customBindingProvider()
         .`in`(ActionScoped::class.java)
     }

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/test/GuiceExtension.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/test/GuiceExtension.kt
@@ -1,7 +1,7 @@
 package com.github.nava2.test
 
 import com.github.nava2.aff4.io.Sha256FileSystemFactory
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.getInstance
 import com.google.inject.Guice
 import com.google.inject.Injector
@@ -115,7 +115,7 @@ class GuiceExtension : BeforeEachCallback, AfterEachCallback, BeforeAllCallback 
     fun afterEach(): Unit = Unit
   }
 
-  private object TestModule : KAbstractModule() {
+  private object TestModule : KAff4AbstractModule() {
     override fun configure() {
       bind<Sha256FileSystemFactory>().toProvider(Provider { Sha256FileSystemFactory() })
 

--- a/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/test/OkioTempFileSystemExtension.kt
+++ b/aff4/aff4-core/aff4-core-test/src/main/kotlin/com/github/nava2/test/OkioTempFileSystemExtension.kt
@@ -79,22 +79,16 @@ class OkioTempFileSystemExtension : BeforeEachCallback, AfterEachCallback {
     @Suppress("UNCHECKED_CAST")
     val tempDirectories = store.get(KEY_PROPERTY_TEMP_DIRS, List::class.java) as? List<Path> ?: listOf()
 
-    val suppressedExceptions = mutableListOf<Exception>()
     for (childDir in tempDirectories) {
       try {
         systemFileSystem.deleteRecursively(childDir)
-      } catch (ex: Exception) {
-        suppressedExceptions += ex
+      } catch (_: Exception) {
       }
     }
 
-    if (suppressedExceptions.isNotEmpty()) {
-      error(
-        "Failed to delete directories due to exceptions: " +
-          suppressedExceptions.joinToString("\n") { it.stackTraceToString() }
-      )
+    try {
+      systemFileSystem.delete(rootDir)
+    } catch (_: Exception) {
     }
-
-    systemFileSystem.delete(rootDir)
   }
 }

--- a/aff4/aff4-core/build.gradle.kts
+++ b/aff4/aff4-core/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   implementation(Dependencies.CHECKER_QUAL)
   implementation(Dependencies.GUAVA)
   implementation(Dependencies.GUICE_ASSISTED_INJECT)
+  implementation(Dependencies.MISK_INJECT)
   implementation(Dependencies.RDF4J_QUERY)
   implementation(Dependencies.RDF4J_REPOSITORY_API)
   implementation(Dependencies.RDF4J_RIO_API)

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4BaseStreamModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4BaseStreamModule.kt
@@ -2,9 +2,9 @@ package com.github.nava2.aff4
 
 import com.github.nava2.aff4.streams.image_stream.Aff4ImageStreamModule
 import com.github.nava2.aff4.streams.map_stream.Aff4MapStreamModule
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 
-object Aff4BaseStreamModule : KAbstractModule() {
+object Aff4BaseStreamModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4CoreModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4CoreModule.kt
@@ -4,10 +4,10 @@ import com.github.nava2.aff4.model.dialect.Aff4ToolDialectModule
 import com.github.nava2.aff4.model.dialect.DialectsModule
 import com.github.nava2.aff4.rdf.RdfRepositoryModule
 import com.github.nava2.aff4.rdf.io.RdfModelParserModule
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScopeModule
 
-object Aff4CoreModule : KAbstractModule() {
+object Aff4CoreModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4LogicalModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/Aff4LogicalModule.kt
@@ -1,9 +1,9 @@
 package com.github.nava2.aff4
 
 import com.github.nava2.aff4.streams.zip_segment.Aff4ZipSegmentModule
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 
-object Aff4LogicalModule : KAbstractModule() {
+object Aff4LogicalModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/RandomsModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/RandomsModule.kt
@@ -1,11 +1,11 @@
 package com.github.nava2.aff4
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.google.inject.Provides
 import java.security.SecureRandom
 import java.util.Random
 
-object RandomsModule : KAbstractModule() {
+object RandomsModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
   }

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/Aff4ContainerBuilderModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/Aff4ContainerBuilderModule.kt
@@ -1,11 +1,11 @@
 package com.github.nava2.aff4.container
 
 import com.github.nava2.aff4.Aff4CoreModule
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.assistedFactoryModule
 import com.github.nava2.guice.implement
 
-internal object Aff4ContainerBuilderModule : KAbstractModule() {
+internal object Aff4ContainerBuilderModule : KAff4AbstractModule() {
   override fun configure() {
     install(
       assistedFactoryModule<Aff4ContainerBuilder.Factory> {

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/Aff4ImageOpenerModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/Aff4ImageOpenerModule.kt
@@ -9,12 +9,12 @@ import com.github.nava2.aff4.model.Aff4StreamOpener
 import com.github.nava2.aff4.model.Aff4StreamOpenerModule
 import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.rdf.RdfExecutor
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScoped
 import com.github.nava2.guice.to
 import com.google.inject.Provides
 
-object Aff4ImageOpenerModule : KAbstractModule() {
+object Aff4ImageOpenerModule : KAff4AbstractModule() {
   override fun configure() {
     install(ImageScopeModule)
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/ImageScopeModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/container/ImageScopeModule.kt
@@ -1,13 +1,13 @@
 package com.github.nava2.aff4.container
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScope
 import com.github.nava2.guice.action_scoped.ActionScopeModule
 import com.github.nava2.guice.action_scoped.ActionScoped
 import com.github.nava2.guice.key
 import javax.inject.Provider
 
-object ImageScopeModule : KAbstractModule() {
+object ImageScopeModule : KAff4AbstractModule() {
   override fun configure() {
     install(ActionScopeModule)
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/Aff4ModelModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/Aff4ModelModule.kt
@@ -1,11 +1,11 @@
 package com.github.nava2.aff4.model
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.assistedFactoryModule
 import com.github.nava2.guice.to
 import java.util.Objects
 
-object Aff4ModelModule : KAbstractModule() {
+object Aff4ModelModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/Aff4StreamOpenerModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/Aff4StreamOpenerModule.kt
@@ -1,10 +1,10 @@
 package com.github.nava2.aff4.model
 
 import com.github.nava2.aff4.streams.Aff4StreamLoaderContext
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.to
 
-internal object Aff4StreamOpenerModule : KAbstractModule() {
+internal object Aff4StreamOpenerModule : KAff4AbstractModule() {
   override fun configure() {
     bind<Aff4StreamOpener>().to<RealAff4StreamOpener>()
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/dialect/DialectsModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/dialect/DialectsModule.kt
@@ -1,10 +1,10 @@
 package com.github.nava2.aff4.model.dialect
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.key
 import com.github.nava2.guice.to
 
-object DialectsModule : KAbstractModule() {
+object DialectsModule : KAff4AbstractModule() {
   override fun configure() {
     install(Aff4ToolDialectModule)
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/dialect/Pyaff4Version11ToolDialect.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/dialect/Pyaff4Version11ToolDialect.kt
@@ -2,7 +2,7 @@ package com.github.nava2.aff4.model.dialect
 
 import com.github.nava2.aff4.model.Aff4Container
 import com.github.nava2.aff4.model.rdf.ZipSegment
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.google.inject.Provides
 import javax.inject.Singleton
 
@@ -11,7 +11,7 @@ class Pyaff4Version11ToolDialect private constructor(override val typeResolver: 
     return toolMetadata == Aff4Container.ToolMetadata(version = "1.1", tool = "pyaff4")
   }
 
-  object Module : KAbstractModule() {
+  object Module : KAff4AbstractModule() {
     override fun configure() {
       install(Aff4ToolDialectModule)
 

--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/AbstractAff4StreamModule.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/streams/AbstractAff4StreamModule.kt
@@ -2,14 +2,14 @@ package com.github.nava2.aff4.streams
 
 import com.github.nava2.aff4.model.Aff4StreamSourceProvider
 import com.github.nava2.aff4.model.rdf.Aff4RdfModel
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.google.inject.Key
 import com.google.inject.TypeLiteral
 
 internal abstract class AbstractAff4StreamModule<C : Aff4RdfModel, S : Aff4StreamSourceProvider>(
   private val configTypeLiteral: TypeLiteral<C>,
   private val loaderKey: Key<out Aff4StreamSourceProvider.Loader<C, S>>,
-) : KAbstractModule() {
+) : KAff4AbstractModule() {
   open fun configureModule() = Unit
 
   final override fun configure() {

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ToolDialectResolverTest.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/container/ToolDialectResolverTest.kt
@@ -7,7 +7,7 @@ import com.github.nava2.aff4.isInstanceOf
 import com.github.nava2.aff4.model.Aff4Container
 import com.github.nava2.aff4.model.dialect.DialectTypeResolver
 import com.github.nava2.aff4.model.dialect.ToolDialect
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.to
 import com.github.nava2.test.GuiceModule
 import com.google.inject.util.Modules
@@ -24,7 +24,7 @@ internal class ToolDialectResolverTest {
     TestToolDialectModule {
       to<DefaultToolDialectImpl>()
     },
-    object : KAbstractModule() {
+    object : KAff4AbstractModule() {
       override fun configure() {
         bindSet<ToolDialect> {
           toInstance(ToolDialectOne)

--- a/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/TestAff4ContainerBuilderModule.kt
+++ b/aff4/aff4-core/src/test/kotlin/com/github/nava2/aff4/streams/TestAff4ContainerBuilderModule.kt
@@ -7,9 +7,9 @@ import com.github.nava2.aff4.container.Aff4ContainerBuilderModule
 import com.github.nava2.aff4.container.Aff4ImageOpenerModule
 import com.github.nava2.aff4.model.Aff4StreamOpenerModule
 import com.github.nava2.aff4.model.rdf.Aff4RdfModelPlugin
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 
-object TestAff4ContainerBuilderModule : KAbstractModule() {
+object TestAff4ContainerBuilderModule : KAff4AbstractModule() {
   override fun configure() {
     install(TestRandomsModule)
     install(TestActionScopeModule)

--- a/aff4/aff4-plugin/build.gradle.kts
+++ b/aff4/aff4-plugin/build.gradle.kts
@@ -1,10 +1,12 @@
 dependencies {
   api(Dependencies.GUICE)
   api(Dependencies.JAVAX_INJECT)
+  api(Dependencies.MISK_INJECT)
 
   api(project(":aff4::aff4-core:aff4-core-model:aff4-core-model-api"))
   api(project(":aff4:aff4-core:aff4-core-guice"))
   api(project(":aff4:aff4-rdf:aff4-rdf-api"))
+
 
   runtimeOnly(Dependencies.RDF4J_REPOSITORY_SAIL)
 }

--- a/aff4/aff4-plugin/src/main/kotlin/com/github/nava2/aff4/plugins/KAff4Plugin.kt
+++ b/aff4/aff4-plugin/src/main/kotlin/com/github/nava2/aff4/plugins/KAff4Plugin.kt
@@ -4,9 +4,9 @@ import com.github.nava2.aff4.model.rdf.Aff4RdfModel
 import com.github.nava2.aff4.model.rdf.CompressionMethod
 import com.github.nava2.aff4.rdf.RdfRepositoryConfiguration
 import com.github.nava2.aff4.rdf.RdfValueConverter
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.KSetMultibinderHelper
-import com.google.inject.binder.AnnotatedBindingBuilder
+import com.google.inject.Binder
 import javax.inject.Qualifier
 import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
@@ -19,7 +19,7 @@ import kotlin.reflect.KClass
  */
 abstract class KAff4Plugin protected constructor(
   pluginIdentifier: String,
-) : KAbstractModule() {
+) : KAff4AbstractModule() {
 
   val pluginIdentifier = PluginIdentifier(name = pluginIdentifier)
 
@@ -39,7 +39,9 @@ abstract class KAff4Plugin protected constructor(
 
   protected abstract fun configurePlugin()
 
-  protected fun bindRdfRepositoryConfiguration(): AnnotatedBindingBuilder<RdfRepositoryConfiguration> = bind()
+  override fun binder(): Binder = super.binder().skipSources(KAff4Plugin::class.java)
+
+  protected fun bindRdfRepositoryConfiguration(): KotlinAnnotatedBindingBuilder<in RdfRepositoryConfiguration> = bind()
 
   protected inline fun bindRdfValueConverters(
     crossinline block: KSetMultibinderHelper<RdfValueConverter<*>>.() -> Unit,

--- a/aff4/aff4-rdf/aff4-rdf-memory/build.gradle.kts
+++ b/aff4/aff4-rdf/aff4-rdf-memory/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 
   implementation(Dependencies.GUICE)
   implementation(Dependencies.JAVAX_INJECT)
+  implementation(Dependencies.MISK_INJECT)
   implementation(Dependencies.RDF4J_SAIL_API)
   implementation(Dependencies.RDF4J_REPOSITORY_SAIL_MEMORY)
 

--- a/aff4/aff4-rdf/build.gradle.kts
+++ b/aff4/aff4-rdf/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   implementation(Dependencies.CHECKER_QUAL)
   implementation(Dependencies.GUAVA)
   implementation(Dependencies.GUICE_ASSISTED_INJECT)
+  implementation(Dependencies.MISK_INJECT)
   implementation(Dependencies.RDF4J_REPOSITORY_SAIL)
   implementation(Dependencies.RDF4J_RIO_TURTLE)
   implementation(Dependencies.RDF4J_SAIL_API)

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/RdfRepositoryModule.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/RdfRepositoryModule.kt
@@ -1,6 +1,6 @@
 package com.github.nava2.aff4.rdf
 
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.assistedFactoryModule
 import com.github.nava2.guice.key
 import com.github.nava2.guice.to
@@ -9,7 +9,7 @@ import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.repository.sail.SailRepository
 import javax.inject.Singleton
 
-object RdfRepositoryModule : KAbstractModule() {
+object RdfRepositoryModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/RdfModelParserModule.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/RdfModelParserModule.kt
@@ -2,13 +2,13 @@ package com.github.nava2.aff4.rdf.io
 
 import com.github.nava2.aff4.model.dialect.ToolDialect
 import com.github.nava2.aff4.rdf.io.literals.RdfLiteralConvertersModule
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 import com.github.nava2.guice.action_scoped.ActionScoped
 import com.github.nava2.guice.assistedFactoryModule
 import com.github.nava2.guice.to
 import com.google.inject.Provides
 
-object RdfModelParserModule : KAbstractModule() {
+object RdfModelParserModule : KAff4AbstractModule() {
   override fun configure() {
     binder().requireAtInjectOnConstructors()
 

--- a/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/literals/RdfLiteralConvertersModule.kt
+++ b/aff4/aff4-rdf/src/main/kotlin/com/github/nava2/aff4/rdf/io/literals/RdfLiteralConvertersModule.kt
@@ -1,9 +1,9 @@
 package com.github.nava2.aff4.rdf.io.literals
 
 import com.github.nava2.aff4.rdf.RdfValueConverter
-import com.github.nava2.guice.KAbstractModule
+import com.github.nava2.guice.KAff4AbstractModule
 
-internal object RdfLiteralConvertersModule : KAbstractModule() {
+internal object RdfLiteralConvertersModule : KAff4AbstractModule() {
   override fun configure() {
     bindSet<RdfValueConverter<*>> {
       to<StringRdfConverter>()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,13 +16,13 @@ object Dependencies {
 
   const val JAVAX_INJECT = "javax.inject:javax.inject:1"
 
-  const val JODA_TIME = "joda-time:joda-time:2.10.14"
-
   const val KINTERVAL_TREE = "net.navatwo:kinterval-tree:0.1.0"
 
   const val LOG4J_API = "org.apache.logging.log4j:log4j-api:${Versions.LOG4J}"
   const val LOG4J_CORE = "org.apache.logging.log4j:log4j-core:${Versions.LOG4J}"
   const val LOG4J_SLF4J = "org.apache.logging.log4j:log4j-slf4j-impl:${Versions.LOG4J}"
+
+  const val MISK_INJECT = "com.squareup.misk:misk-inject:0.24.0"
 
   const val OKIO = "com.squareup.okio:okio:3.1.0"
 


### PR DESCRIPTION
The intention for this is to allow reuse of the `misk-action-scopes` (#55) removing extra code within this library.

Closes #56.