### PR TITLE
[Misk ActionScoped] Fix early initialize defect in `RealAff4StreamOpener`

### DIFF
--- a/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/RealAff4StreamOpener.kt
+++ b/aff4/aff4-core/src/main/kotlin/com/github/nava2/aff4/model/RealAff4StreamOpener.kt
@@ -29,6 +29,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Proxy
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.javaType
@@ -45,21 +46,11 @@ internal class RealAff4StreamOpener @Inject constructor(
   private val rdfModelParser: RdfModelParser,
   private val modelKlasses: Set<KClass<out Aff4RdfModel>>,
   aff4StreamLoaderContexts: Set<Aff4StreamLoaderContext>,
-  @ActionScoped private val toolDialect: ToolDialect,
+  @ActionScoped private val toolDialectProvider: Provider<ToolDialect>,
   private val symbolics: Symbolics,
 ) : Aff4StreamOpener {
   @Volatile
   private var closed = false
-
-  private val modelKlassesByRdfType: Map<IRI, KClass<out Aff4RdfModel>> =
-    rdfExecutor.withReadOnlySession { connection ->
-      modelKlasses.asSequence()
-        .flatMap { klass ->
-          val rdfModelTypes = toolDialect.typeResolver.getAll(klass).asSequence()
-          rdfModelTypes.map { connection.namespaces.iriFromTurtle(it) to klass }
-        }
-        .toMap()
-    }
 
   private val aff4StreamLoaderContexts = aff4StreamLoaderContexts.associateBy { it.configTypeLiteral }
 
@@ -162,7 +153,7 @@ internal class RealAff4StreamOpener @Inject constructor(
       .mapNotNull { it.`object` as? Aff4Arn }
       .toSet()
 
-    val modelType = rdfTypes.asSequence().mapNotNull { type -> modelKlassesByRdfType[type] }
+    val modelType = getModelKlassesForTypes(rdfTypes)
       .firstOrNull { TypeLiteral.get(it.java) in aff4StreamLoaderContexts }
       ?: error("Could not load Stream: $streamIri")
 
@@ -177,6 +168,22 @@ internal class RealAff4StreamOpener @Inject constructor(
 
     openStreams.invalidateAll()
     openStreams.cleanUp()
+  }
+
+  private fun getModelKlassesForTypes(types: Set<IRI>): Set<KClass<out Aff4RdfModel>> {
+    // TODO We should cache this per RDF session, this is more than likely operating within
+    //      a session. Thus it can be reused.
+    return rdfExecutor.withReadOnlySession { connection ->
+      modelKlasses.asSequence()
+        .flatMap { klass ->
+          val rdfModelTypes = toolDialectProvider.get().typeResolver.getAll(klass)
+          rdfModelTypes.asSequence()
+            .map { connection.namespaces.iriFromTurtle(it) to klass }
+            .filter { (iri, _) -> iri in types }
+            .map { (_, klass) -> klass }
+        }
+        .toSet()
+    }
   }
 }
 


### PR DESCRIPTION
In some scenarios, we would load the namespaces prior to opening the proper scope and thus initialize the class with an invalid mapping of model <-> IRI mapping. This fixes this by recomputing on request.

This works towards #55 and was extracted from #61.