### PR TITLE
[dependabot] Fix dependabot from automerging all requests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,14 +16,18 @@ jobs:
         with:
           github-token: "${{secrets.GITHUB_TOKEN}}"
 
-      - name: Enable auto-merge for Dependabot PRs
-        if: |
-          ${{
-            steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
-              (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' && 
-                contains(join(steps.metadata.outputs.dependency-names, ';'), 'com.squareup.misk:misk-')
-              )
-            }}
+      - name: Enable auto-merge for minor patch bumps
+        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge for misk minor patch bumps
+        if: ${{
+          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' &&
+          contains(join(steps.metadata.outputs.dependency-names, ';'), 'com.squareup.misk:misk-')
+          }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Dependabot integration seems to be merging _all_ minor patches, those should be reviewed. Example:

* https://github.com/kaff4/kaff4/pull/141
  <img width="736" alt="image" src="https://github.com/kaff4/kaff4/assets/302365/e2a0f48c-94a3-4ba9-8c32-54e5c387763c">
