### PR TITLE
[dependabot] Fix dependabot-auto-merge.yml

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,21 +14,23 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
-          github-token: "${{secrets.GITHUB_TOKEN}}"
+          github-token: "${{secrets.GITHUB_TOKEN}}" 
 
       - name: Enable auto-merge for minor patch bumps
-        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: |
+          gh pr merge --auto --merge "$PR_URL" 
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge for misk minor patch bumps
         if: ${{
-          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
           contains(join(steps.metadata.outputs.dependency-names, ';'), 'com.squareup.misk:misk-')
           }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Turns out there was a typo on `dependabot-` instead of just `metadata` for the id for the steps.