### PR TITLE
[Sources] Add `AbstractSource` to encapsulate common logic

### DIFF
--- a/kaff4-core/build.gradle.kts
+++ b/kaff4-core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation(libs.fastcdc4j)
 
   implementation(project(":kaff4-core:kaff4-core-kotlin"))
+  implementation(project(":kaff4-core:kaff4-core-sources"))
   implementation(project(":kaff4-rdf"))
 
   testImplementation(libs.assertj)

--- a/kaff4-core/kaff4-core-okio/api/kaff4-core-okio.api
+++ b/kaff4-core/kaff4-core-okio/api/kaff4-core-okio.api
@@ -44,14 +44,14 @@ public final class net/navatwo/kaff4/io/FileSystemPathSourceProviderKt {
 	public static final fun sourceProvider (Lokio/FileSystem;Lokio/Path;)Lnet/navatwo/kaff4/io/FileSystemPathSourceProvider;
 }
 
-public final class net/navatwo/kaff4/io/ListSourceProviderConcatLazilyExtensionKt {
-	public static final fun concatLazily (Ljava/util/List;)Lnet/navatwo/kaff4/io/SourceProvider;
-}
-
-public final class net/navatwo/kaff4/io/OkioFixedLengthSourceProviderExtensionsKt {
+public final class net/navatwo/kaff4/io/FixedLengthSourceProviderExtensionsKt {
 	public static final fun bounded (Lnet/navatwo/kaff4/io/SourceProvider;JJ)Lnet/navatwo/kaff4/io/SourceProvider;
 	public static final fun limit (Lnet/navatwo/kaff4/io/SourceProvider;J)Lnet/navatwo/kaff4/io/SourceProvider;
 	public static final fun offset (Lnet/navatwo/kaff4/io/SourceProvider;J)Lnet/navatwo/kaff4/io/SourceProvider;
+}
+
+public final class net/navatwo/kaff4/io/ListSourceProviderConcatLazilyExtensionKt {
+	public static final fun concatLazily (Ljava/util/List;)Lnet/navatwo/kaff4/io/SourceProvider;
 }
 
 public final class net/navatwo/kaff4/io/RelativeFileSystem : okio/ForwardingFileSystem {

--- a/kaff4-core/kaff4-core-okio/build.gradle.kts
+++ b/kaff4-core/kaff4-core-okio/build.gradle.kts
@@ -6,7 +6,9 @@ dependencies {
   api(libs.guava)
 
   implementation(libs.okio)
-  
+
+  implementation(project(":kaff4-core:kaff4-core-sources"))
+
   compileOnly(project(":kaff4-api"))
 
   testImplementation(libs.assertj)

--- a/kaff4-core/kaff4-core-okio/src/main/kotlin/net/navatwo/kaff4/io/ListSourceProviderConcatLazilyExtension.kt
+++ b/kaff4-core/kaff4-core-okio/src/main/kotlin/net/navatwo/kaff4/io/ListSourceProviderConcatLazilyExtension.kt
@@ -27,13 +27,11 @@ internal class LazyConcatSourceProvider(
 private class LazyConcatSource(
   private val lazySources: List<SourceProvider<Source>>,
   private val timeout: Timeout,
-) : Source {
+) : AbstractSource(timeout) {
   private val iter = lazySources.iterator()
   private var current: Source = iter.next().source(timeout = timeout)
 
-  override fun read(sink: Buffer, byteCount: Long): Long {
-    timeout.throwIfReached()
-
+  override fun protectedRead(sink: Buffer, byteCount: Long): Long {
     val bytesRead = current.read(sink, byteCount)
 
     return when {
@@ -49,8 +47,9 @@ private class LazyConcatSource(
     }
   }
 
-  override fun close() = current.close()
-  override fun timeout(): Timeout = timeout
+  override fun exhausted(): Exhausted = Exhausted.UNKNOWN
+
+  override fun protectedClose() = current.close()
 
   override fun toString(): String = "lazyConcatSource(Sources(${lazySources.size}))"
 }

--- a/kaff4-core/kaff4-core-okio/src/main/kotlin/net/navatwo/kaff4/io/NullSourceProvider.kt
+++ b/kaff4-core/kaff4-core-okio/src/main/kotlin/net/navatwo/kaff4/io/NullSourceProvider.kt
@@ -11,12 +11,12 @@ internal object NullSourceProvider : SourceProvider<Source> {
   }
 }
 
-private class NullSource private constructor(private val timeout: Timeout) : Source {
-  override fun close() = Unit
+private class NullSource private constructor(timeout: Timeout) : AbstractSource(timeout) {
+  override fun protectedClose() = Unit
 
-  override fun read(sink: Buffer, byteCount: Long): Long = -1L
+  override fun protectedRead(sink: Buffer, byteCount: Long): Long = -1L
 
-  override fun timeout(): Timeout = timeout
+  override fun exhausted(): Exhausted = Exhausted.EXHAUSTED
 
   override fun toString(): String {
     return "null(size = 0L)"

--- a/kaff4-core/kaff4-core-sources/api/kaff4-core-sources.api
+++ b/kaff4-core/kaff4-core-sources/api/kaff4-core-sources.api
@@ -1,0 +1,25 @@
+public abstract class net/navatwo/kaff4/io/AbstractSource : okio/Source {
+	protected fun <init> (Lokio/Timeout;)V
+	protected final fun checkClosedOrTimedOut ()V
+	public final fun close ()V
+	protected abstract fun exhausted ()Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+	protected abstract fun protectedClose ()V
+	protected abstract fun protectedRead (Lokio/Buffer;J)J
+	public final fun read (Lokio/Buffer;J)J
+	public final fun timeout ()Lokio/Timeout;
+}
+
+protected final class net/navatwo/kaff4/io/AbstractSource$Exhausted : java/lang/Enum {
+	public static final field Companion Lnet/navatwo/kaff4/io/AbstractSource$Exhausted$Companion;
+	public static final field EXHAUSTED Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+	public static final field HAS_VALUES Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+	public static final field UNKNOWN Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+	public static fun values ()[Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+}
+
+public final class net/navatwo/kaff4/io/AbstractSource$Exhausted$Companion {
+	public final fun from (Z)Lnet/navatwo/kaff4/io/AbstractSource$Exhausted;
+}
+

--- a/kaff4-core/kaff4-core-sources/build.gradle.kts
+++ b/kaff4-core/kaff4-core-sources/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("kaff4.library")
+}
+
+dependencies {
+  implementation(libs.okio)
+  
+  compileOnly(project(":kaff4-api"))
+}

--- a/kaff4-core/kaff4-core-sources/src/main/kotlin/net/navatwo/kaff4/io/AbstractSource.kt
+++ b/kaff4-core/kaff4-core-sources/src/main/kotlin/net/navatwo/kaff4/io/AbstractSource.kt
@@ -1,0 +1,52 @@
+package net.navatwo.kaff4.io
+
+import okio.Buffer
+import okio.Source
+import okio.Timeout
+
+abstract class AbstractSource protected constructor(
+  private val timeout: Timeout,
+) : Source {
+  @Volatile
+  private var closed = false
+
+  final override fun read(sink: Buffer, byteCount: Long): Long {
+    checkClosedOrTimedOut()
+    require(byteCount >= 0) { "byteCount >= 0" }
+
+    if (exhausted() == Exhausted.EXHAUSTED) return -1L
+
+    return protectedRead(sink, byteCount)
+  }
+
+  final override fun timeout(): Timeout = timeout
+
+  final override fun close() {
+    if (closed) return
+
+    closed = true
+    protectedClose()
+  }
+
+  protected abstract fun protectedRead(sink: Buffer, byteCount: Long): Long
+
+  protected abstract fun protectedClose()
+
+  protected abstract fun exhausted(): Exhausted
+
+  protected enum class Exhausted {
+    HAS_VALUES,
+    EXHAUSTED,
+    UNKNOWN,
+    ;
+
+    companion object {
+      fun from(exhausted: Boolean) = if (exhausted) EXHAUSTED else HAS_VALUES
+    }
+  }
+
+  protected fun checkClosedOrTimedOut() {
+    check(!closed) { "closed" }
+    timeout.throwIfReached()
+  }
+}

--- a/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/io/SourceExtensions.kt
+++ b/kaff4-core/kaff4-core-test/src/main/kotlin/net/navatwo/kaff4/io/SourceExtensions.kt
@@ -30,7 +30,7 @@ private fun <SELF, T> SELF.computeHashAssert(
   byteCount: Long,
   computeHash: KCallable<ByteString>,
 ): AbstractObjectAssert<*, ByteString>
-  where SELF : AbstractObjectAssert<SELF, T>, T : Source {
+  where SELF : AbstractObjectAssert<out SELF, T>, T : Source {
   lateinit var sourceString: String
   return `as` { "${computeHash.name}($sourceString)" }
     .extracting { source: T ->

--- a/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/map_stream/MapIdxFileReader.kt
+++ b/kaff4-core/src/main/kotlin/net/navatwo/kaff4/streams/map_stream/MapIdxFileReader.kt
@@ -23,7 +23,8 @@ internal class MapIdxFileReader @Inject constructor(
     .maximumSize(MAP_TARGETS_CACHE_SIZE)
     .build<CacheKey, List<Aff4Arn>> { key ->
       containerDataFileSystemProvider[key.stored]
-        .source(key.mapIdxPath).buffer()
+        .source(key.mapIdxPath)
+        .buffer()
         .use { s ->
           s.lineSequence().map { valueFactory.createArn(it) }.toList()
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include(
   "kaff4-core:kaff4-core-model",
   "kaff4-core:kaff4-core-model:kaff4-core-model-api",
   "kaff4-core:kaff4-core-okio",
+  "kaff4-core:kaff4-core-sources",
   "kaff4-core:kaff4-core-test",
   "kaff4-rdf",
   "kaff4-rdf:kaff4-rdf-api",


### PR DESCRIPTION
This was needed long ago, it defines a new project + `AbstractSource` to avoid replicated logic checks.