### PR TITLE
[dependably] update Misk monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
       interval: "daily"
       time: '09:00'
       timezone: 'America/Toronto'
-
+    ignore:
+      # Misk updates daily, there's little to no benefit to these
+      # updates, so we only do it monthly.
+      - dependency-name: "misk"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Updating Misk daily is a useless chore. This adjusts it to be monthly instead. 