### PR TITLE
[CI] Upgrade CI to use better caching to reduce build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: Build and test
 on: [ pull_request ]
 jobs:
-  JVM-Run-Gradle-Check:
+  ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
 
@@ -17,11 +17,12 @@ jobs:
       - name: Verify gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Build kaff4
-        uses: burrunan/gradle-cache-action@v1
+      - name: Run CI checks
+        uses: gradle/gradle-build-action@v2
+        id: gradle
         with:
-          arguments: check buildHealth --continue
-
+          arguments: check buildHealth --scan --continue
+          
       - name: Verify build health
         run: |
           BUILD_HEALTH_REPORT="./build/reports/dependency-analysis/build-health-report.txt"
@@ -33,9 +34,10 @@ jobs:
             exit 1
           fi
 
-      - name: Upload build reports
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: build-reports
-          path: ./**/build/reports/
+      - name: "Add Build Scan URL as PR comment"
+        if: github.event_name == 'pull_request' && failure()
+        run: |
+          gh pr comment ${{ github.event.number }} \
+              --body "❌ ${{ github.workflow }} failed: ${{ steps.gradle.outputs.build-scan-url }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Upgrade how we do CI to reduce time and cost. Originally the gradle actions cache wasn't very strong, it's been improved and this swaps it up!