### PR TITLE
Dependabot: Adjust misk to only do major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
       # Misk updates daily, there's little to no benefit to these
       # updates, so we only do it monthly.
       - dependency-name: "misk"
-        update-types: ["version-update:semver-minor"]
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This is to avoid updating the dependency daily -- its a waste of resources.